### PR TITLE
support for isolated routes to solve multiple instances problem

### DIFF
--- a/example/index2.ts
+++ b/example/index2.ts
@@ -1,35 +1,44 @@
 import { Elysia } from 'elysia'
 import { swagger } from '../src/index'
-
-const firstApp = new Elysia({ prefix: '/first' })
-
-firstApp
-	.get('/first-route', () => {
-		return 'first route!'
-	})
-	.use(
-		swagger({
-			path: '/first-doc',
-			routes: firstApp.routes
-		})
-	)
-
-const secondApp = new Elysia({ prefix: '/second' })
-
-secondApp
-	.get('/second-route', () => {
-		return 'second route!'
-	})
-	.use(
-		swagger({
-			path: '/second-doc',
-			routes: secondApp.routes
-		})
-	)
+import { plugin } from './plugin'
 
 const app = new Elysia({
 	// aot: false
 })
-	.use(firstApp)
-	.use(secondApp)
+	.use(
+		swagger({
+			documentation: {
+				info: {
+					title: 'Elysia',
+					version: '0.6.10'
+				},
+				tags: [
+					{
+						name: 'Test',
+						description: 'Hello'
+					}
+				],
+				security: [{ JwtAuth: [] }],
+				components: {
+					schemas: {
+						User: {
+							description: 'string'
+						}
+					},
+					securitySchemes: {
+						JwtAuth: {
+							type: 'http',
+							scheme: 'bearer',
+							bearerFormat: 'JWT',
+							description: 'Enter JWT Bearer token **_only_**'
+						}
+					}
+				}
+			},
+			swaggerOptions: {
+				persistAuthorization: true
+			}
+		})
+	)
+	.use(plugin)
 	.listen(3000)

--- a/example/index2.ts
+++ b/example/index2.ts
@@ -1,46 +1,35 @@
 import { Elysia } from 'elysia'
 import { swagger } from '../src/index'
-import { plugin } from './plugin'
+
+const firstApp = new Elysia({ prefix: '/first' })
+
+firstApp
+	.get('/first-route', () => {
+		return 'first route!'
+	})
+	.use(
+		swagger({
+			path: '/first-doc',
+			routes: firstApp.routes
+		})
+	)
+
+const secondApp = new Elysia({ prefix: '/second' })
+
+secondApp
+	.get('/second-route', () => {
+		return 'second route!'
+	})
+	.use(
+		swagger({
+			path: '/second-doc',
+			routes: secondApp.routes
+		})
+	)
 
 const app = new Elysia({
-    // aot: false
+	// aot: false
 })
-    .use(
-        swagger({
-            documentation: {
-                info: {
-                    title: 'Elysia',
-                    version: '0.6.10'
-                },
-                tags: [
-                    {
-                        name: 'Test',
-                        description: 'Hello'
-                    }
-                ],
-                security: [
-                    {JwtAuth: []}
-                ],
-                components: {
-                    schemas: {
-                        User: {
-                            description: 'string'
-                        }
-                    },
-                    securitySchemes: {
-                        JwtAuth: {
-                            type: 'http',
-                            scheme: 'bearer',
-                            bearerFormat: 'JWT',
-                            description: 'Enter JWT Bearer token **_only_**'
-                        }
-                    }
-                }
-            },
-            swaggerOptions: {
-                persistAuthorization: true
-            },
-        })
-    )
-    .use(plugin)
-    .listen(3000)
+	.use(firstApp)
+	.use(secondApp)
+	.listen(3000)

--- a/example/multiple-instancies.ts
+++ b/example/multiple-instancies.ts
@@ -1,0 +1,35 @@
+import { Elysia } from 'elysia'
+import { swagger } from '../src/index'
+
+const firstApp = new Elysia({ prefix: '/first' })
+
+firstApp
+	.get('/first-route', () => {
+		return 'first route!'
+	})
+	.use(
+		swagger({
+			path: '/first-doc',
+			routes: firstApp.routes
+		})
+	)
+
+const secondApp = new Elysia({ prefix: '/second' })
+
+secondApp
+	.get('/second-route', () => {
+		return 'second route!'
+	})
+	.use(
+		swagger({
+			path: '/second-doc',
+			routes: secondApp.routes
+		})
+	)
+
+const app = new Elysia({
+	// aot: false
+})
+	.use(firstApp)
+	.use(secondApp)
+	.listen(3000)

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ export const swagger = async <Path extends string = '/swagger'>(
 		theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,
 		autoDarkMode = true,
 		excludeMethods = ['OPTIONS'],
-		excludeTags = []
+		excludeTags = [],
+		routes
 	}: ElysiaSwaggerConfig<Path> = {
 		provider: 'scalar',
 		scalarVersion: 'latest',
@@ -96,8 +97,13 @@ export const swagger = async <Path extends string = '/swagger'>(
 						theme,
 						stringifiedSwaggerOptions,
 						autoDarkMode
-					)
-				: ScalarRender(info, scalarVersion, scalarConfiguration, scalarCDN),
+				  )
+				: ScalarRender(
+						info,
+						scalarVersion,
+						scalarConfiguration,
+						scalarCDN
+				  ),
 			{
 				headers: {
 					'content-type': 'text/html; charset=utf8'
@@ -105,18 +111,33 @@ export const swagger = async <Path extends string = '/swagger'>(
 			}
 		)
 	}).get(path === '/' ? '/json' : `${path}/json`, function openAPISchema() {
-		// @ts-expect-error Private property
-		const routes = app.getGlobalRoutes() as InternalRoute[]
+		const allRoutes = routes
+			? [...routes, ...app.routes]
+			: // @ts-expect-error Private property
+			  (app.getGlobalRoutes() as InternalRoute[])
 
-		if (routes.length !== totalRoutes) {
-			const ALLOWED_METHODS = ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE']
-			totalRoutes = routes.length
+		if (allRoutes.length !== totalRoutes) {
+			const ALLOWED_METHODS = [
+				'GET',
+				'PUT',
+				'POST',
+				'DELETE',
+				'OPTIONS',
+				'HEAD',
+				'PATCH',
+				'TRACE'
+			]
+			totalRoutes = allRoutes.length
 
-			routes.forEach((route: InternalRoute) => {
+			allRoutes.forEach((route: InternalRoute) => {
 				if (route.hooks?.detail?.hide === true) return
 				// TODO: route.hooks?.detail?.hide !== false  add ability to hide: false to prevent excluding
 				if (excludeMethods.includes(route.method)) return
-				if (ALLOWED_METHODS.includes(route.method) === false && route.method !== 'ALL') return
+				if (
+					ALLOWED_METHODS.includes(route.method) === false &&
+					route.method !== 'ALL'
+				)
+					return
 
 				if (route.method === 'ALL') {
 					ALLOWED_METHODS.forEach((method) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,119 +1,127 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
+import type { InternalRoute } from 'elysia'
 
 export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
-    /**
-     * Customize Swagger config, refers to Swagger 2.0 config
-     *
-     * @see https://swagger.io/specification/v2/
-     */
-    documentation?: Omit<
-        Partial<OpenAPIV3.Document>,
-        | 'x-express-openapi-additional-middleware'
-        | 'x-express-openapi-validation-strict'
-    >
-    /**
-     * Choose your provider, Scalar or Swagger UI
-     *
-     * @default 'scalar'
-     * @see https://github.com/scalar/scalar
-     * @see https://github.com/swagger-api/swagger-ui
-     */
-    provider?: 'scalar' | 'swagger-ui'
-    /**
-     * Version to use for Scalar cdn bundle
-     *
-     * @default 'latest'
-     * @see https://github.com/scalar/scalar
-     */
-    scalarVersion?: string
-    /**
-     * Optional override to specifying the path for the Scalar bundle
-     *
-     * Custom URL or path to locally hosted Scalar bundle 
-     *
-     * Lease blank to use default jsdeliver.net CDN
-     *
-     * @default ''
-     * @example 'https://unpkg.com/@scalar/api-reference@1.13.10/dist/browser/standalone.js'
-     * @example '/public/standalone.js'
-     * @see https://github.com/scalar/scalar
-     */
-    scalarCDN?: string
-    /**
-     * Scalar configuration to customize scalar
-     *'
-     * @see https://github.com/scalar/scalar/blob/main/documentation/configuration.md
-     */
-    scalarConfig?: ReferenceConfiguration
-    /**
-     * Version to use for swagger cdn bundle
-     *
-     * @see unpkg.com/swagger-ui-dist
-     *
-     * @default 4.18.2
-     */
-    version?: string
-    /**
-     * Determine if Swagger should exclude static files.
-     *
-     * @default true
-     */
-    excludeStaticFile?: boolean
-    /**
-     * The endpoint to expose Swagger
-     *
-     * @default '/swagger'
-     */
-    path?: Path
-    /**
-     * Paths to exclude from Swagger endpoint
-     *
-     * @default []
-     */
-    exclude?: string | RegExp | (string | RegExp)[]
-    /**
-     * Options to send to SwaggerUIBundle
-     * Currently, options that are defined as functions such as requestInterceptor
-     * and onComplete are not supported.
-     */
-    swaggerOptions?: Omit<
-        Partial<SwaggerUIOptions>,
-        | 'dom_id'
-        | 'dom_node'
-        | 'spec'
-        | 'url'
-        | 'urls'
-        | 'layout'
-        | 'pluginsOptions'
-        | 'plugins'
-        | 'presets'
-        | 'onComplete'
-        | 'requestInterceptor'
-        | 'responseInterceptor'
-        | 'modelPropertyMacro'
-        | 'parameterMacro'
-    >
-    /**
-     * Custom Swagger CSS
-     */
-    theme?: string | {
-        light: string
-        dark: string
-    }
-    /**
-     * Using poor man dark mode 😭
-     */
-    autoDarkMode?: boolean
+	/**
+	 * Customize Swagger config, refers to Swagger 2.0 config
+	 *
+	 * @see https://swagger.io/specification/v2/
+	 */
+	documentation?: Omit<
+		Partial<OpenAPIV3.Document>,
+		| 'x-express-openapi-additional-middleware'
+		| 'x-express-openapi-validation-strict'
+	>
+	/**
+	 * Choose your provider, Scalar or Swagger UI
+	 *
+	 * @default 'scalar'
+	 * @see https://github.com/scalar/scalar
+	 * @see https://github.com/swagger-api/swagger-ui
+	 */
+	provider?: 'scalar' | 'swagger-ui'
+	/**
+	 * Version to use for Scalar cdn bundle
+	 *
+	 * @default 'latest'
+	 * @see https://github.com/scalar/scalar
+	 */
+	scalarVersion?: string
+	/**
+	 * Optional override to specifying the path for the Scalar bundle
+	 *
+	 * Custom URL or path to locally hosted Scalar bundle
+	 *
+	 * Lease blank to use default jsdeliver.net CDN
+	 *
+	 * @default ''
+	 * @example 'https://unpkg.com/@scalar/api-reference@1.13.10/dist/browser/standalone.js'
+	 * @example '/public/standalone.js'
+	 * @see https://github.com/scalar/scalar
+	 */
+	scalarCDN?: string
+	/**
+	 * Scalar configuration to customize scalar
+	 *'
+	 * @see https://github.com/scalar/scalar/blob/main/documentation/configuration.md
+	 */
+	scalarConfig?: ReferenceConfiguration
+	/**
+	 * Version to use for swagger cdn bundle
+	 *
+	 * @see unpkg.com/swagger-ui-dist
+	 *
+	 * @default 4.18.2
+	 */
+	version?: string
+	/**
+	 * Determine if Swagger should exclude static files.
+	 *
+	 * @default true
+	 */
+	excludeStaticFile?: boolean
+	/**
+	 * The endpoint to expose Swagger
+	 *
+	 * @default '/swagger'
+	 */
+	path?: Path
+	/**
+	 * Paths to exclude from Swagger endpoint
+	 *
+	 * @default []
+	 */
+	exclude?: string | RegExp | (string | RegExp)[]
+	/**
+	 * Options to send to SwaggerUIBundle
+	 * Currently, options that are defined as functions such as requestInterceptor
+	 * and onComplete are not supported.
+	 */
+	swaggerOptions?: Omit<
+		Partial<SwaggerUIOptions>,
+		| 'dom_id'
+		| 'dom_node'
+		| 'spec'
+		| 'url'
+		| 'urls'
+		| 'layout'
+		| 'pluginsOptions'
+		| 'plugins'
+		| 'presets'
+		| 'onComplete'
+		| 'requestInterceptor'
+		| 'responseInterceptor'
+		| 'modelPropertyMacro'
+		| 'parameterMacro'
+	>
+	/**
+	 * Custom Swagger CSS
+	 */
+	theme?:
+		| string
+		| {
+				light: string
+				dark: string
+		  }
+	/**
+	 * Using poor man dark mode 😭
+	 */
+	autoDarkMode?: boolean
 
-    /**
-     * Exclude methods from Swagger
-     */
-    excludeMethods?: string[]
+	/**
+	 * Exclude methods from Swagger
+	 */
+	excludeMethods?: string[]
 
-    /**
-     * Exclude tags from Swagger or Scalar
-     */
-    excludeTags?: string[]
+	/**
+	 * Exclude tags from Swagger or Scalar
+	 */
+	excludeTags?: string[]
+
+	/**
+	 * specific route context
+	 */
+	routes?: InternalRoute[]
 }


### PR DESCRIPTION
This modification solves the issue of isolating routes and adding more swagger instances in Elysia using app.group() and uses the elysia routes api which gets the routes from the context

fix #138

```ts
const firstApp = new Elysia({ prefix: '/first' })

firstApp
	.get('/first-route', () => {
		return 'first route!'
	})
	.use(
		swagger({
			path: '/first-doc',
			routes: firstApp.routes
		})
	)

const secondApp = new Elysia({ prefix: '/second' })

secondApp
	.get('/second-route', () => {
		return 'second route!'
	})
	.use(
		swagger({
			path: '/second-doc',
			routes: secondApp.routes
		})
	)

const app = new Elysia({
	// aot: false
})
	.use(firstApp)
	.use(secondApp)
	.listen(3000)
```

this way we can isolate into groups and have two instances with different paths and separate the documentation without needing a lot of code
