### PR TITLE
fix: disallowed operation called within global scope on Cloudflare Workers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export const openapi = <
 
 			return app.get(
 				path,
-				new Response(
+				() => new Response(
 					provider === 'swagger-ui'
 						? SwaggerUIRender(info, {
 								url: relativePath,


### PR DESCRIPTION
Fix #230 