### PR TITLE
🔧 fix: remove `tsup` import from `openapi.ts`

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -10,7 +10,6 @@ import type {
 	ElysiaOpenAPIConfig,
 	MapJsonSchema
 } from './types'
-import { defineConfig } from 'tsup'
 
 export const capitalize = (word: string) =>
 	word.charAt(0).toUpperCase() + word.slice(1)


### PR DESCRIPTION
There’s an unused `tsup` import at the top of `src/openapi.ts`.

I also noticed that while the repository already includes ESLint and Prettier, there are currently no CI checks set up for them.  
Additionally, ESLint is still using the legacy configuration format.

> [!NOTE]  
> I’d like to open a PR to migrate the ESLint configuration to the new format and add CI steps to enforce linting and formatting checks if you’d like.
