### PR TITLE
fix: add type-gen support for alphanumeric paths

### DIFF
--- a/src/gen/index.ts
+++ b/src/gen/index.ts
@@ -2,7 +2,7 @@ import { TypeBox } from '@sinclair/typemap'
 import type { AdditionalReference } from '../types'
 
 const matchRoute = /: Elysia<(.*)>/gs
-const numberKey = /(\d+):/g
+const propertyKey = /([A-Za-z_]\w*|\d+):/g
 
 export interface OpenAPIGeneratorOptions {
 	/**
@@ -120,7 +120,8 @@ export function declarationToJSONSchema(declaration: string) {
 
 	// Treaty is a collection of { ... } & { ... } & { ... }
 	for (const route of extractRootObjects(
-		declaration.replace(numberKey, '"$1":')
+		// Ensure all property keys are wrapped in quotations
+		declaration.replace(propertyKey, '"$1":')
 	)) {
 		let schema = TypeBox(route.replaceAll(/readonly/g, ''))
 		if (schema.type !== 'object') continue

--- a/test/gen/index.test.ts
+++ b/test/gen/index.test.ts
@@ -425,6 +425,61 @@ describe('Gen > Type Gen', () => {
 		})
 	})
 
+	it('handle alphanumeric route keys like v1', () => {
+		const reference = declarationToJSONSchema(`
+			{
+				v1: {
+					foo: {
+						get: {
+							params: {}
+							query: {}
+							headers: {}
+							body: {}
+							response: {
+								200: {
+									value: number
+								}
+							}
+						}
+					}
+				}
+			}`)
+
+		expect(serializable(reference)!).toEqual({
+			'/v1/foo': {
+				get: {
+					body: {
+						properties: {},
+						type: 'object'
+					},
+					headers: {
+						properties: {},
+						type: 'object'
+					},
+					params: {
+						properties: {},
+						type: 'object'
+					},
+					query: {
+						properties: {},
+						type: 'object'
+					},
+					response: {
+						'200': {
+							properties: {
+								value: {
+									type: 'number'
+								}
+							},
+							required: ['value'],
+							type: 'object'
+						}
+					}
+				}
+			}
+		})
+	})
+
 	it('integrate', async () => {
 		const reference = fromTypes('test/gen/sample.ts')()
 


### PR DESCRIPTION
## Issue

Fixes: https://github.com/elysiajs/elysia-openapi/issues/298

Elysia’s fromTypes() type generation fails when a route path contains alphanumeric segments (e.g. /v1, /v2/foo).

For example this snippet.

```ts
import { Elysia } from 'elysia'
import openapi, { fromTypes } from '@elysiajs/openapi'

export const app = new Elysia()
  .use(openapi({
    references: fromTypes('<path-to-this-file>.ts'),
  }))
  .get('/v', () => 5 as const)    // ✅ works
  .get('/1', () => 5 as const)    // ✅ works
  .get('/v1', () => 5 as const)   // ❌ fails
  .get('/v1/foo', () => 5 as const) // ❌ fails

console.log(JSON.stringify(fromTypes('<path-to-this-file>.ts')(), null, 2))
```

## Root Cause

During type generation, the declaration string is parsed and numeric keys are quoted using this regex:
```ts
const numberKey = /(\d+):/g
```

This works for numeric property keys:
```diff
- 1: { ... }
+ "1": { ... } ✅ 
```

But breaks for alphanumeric property keys:
```diff
- v1: { ... }
+ v"1": { ... } ❌
```

## Fix

Replace the numeric-only key matcher with a more general regex that safely quotes all unquoted valid property keys.

This results in
```diff
- v1: { ... }
+ "v1": { ... } ✅
- 2: { ... }
+ "2": { ... } ✅
- foo: { ... }
+ "foo": { ... } ✅
```