### PR TITLE
feat: support RegExp patterns in exclude.paths

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -693,6 +693,8 @@ export function toOpenAPISchema(
 			? [exclude.paths]
 			: []
 
+	const ignorePatterns = excludePaths.filter((path) => path instanceof RegExp)
+
 	const paths: OpenAPIV3.PathsObject = Object.create(null)
 	// @ts-ignore
 	const definitions = app.getGlobalDefinitions?.().type
@@ -715,11 +717,13 @@ export function toOpenAPISchema(
 		if (route.hooks?.detail?.hide) continue
 
 		const method = route.method.toLowerCase()
+		const shouldExclude = ignorePatterns.some((pattern) => pattern.test(route.path))
 
 		if (
 			(excludeStaticFile && route.path.includes('.')) ||
 			excludePaths.includes(route.path) ||
-			excludeMethods.includes(method)
+			excludeMethods.includes(method) ||
+			shouldExclude
 		)
 			continue
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -693,7 +693,9 @@ export function toOpenAPISchema(
 			? [exclude.paths]
 			: []
 
-	const ignorePatterns = excludePaths.filter((path) => path instanceof RegExp)
+	const ignorePatterns: RegExp[] = excludePaths.filter(
+		(path): path is RegExp => path instanceof RegExp
+	)
 
 	const paths: OpenAPIV3.PathsObject = Object.create(null)
 	// @ts-ignore


### PR DESCRIPTION
### 🚀 Summary
This PR introduces support for **Regular Expressions** in the `exclude.paths` configuration. Previously, the plugin only supported exact string matches, making it difficult to exclude large sets of routes or dynamic path segments.

### 🛠️ The Problem
When managing large APIs, users often need to exclude entire modules, versions, or internal tools (e.g., all `/v1` or `/internal` routes) from the OpenAPI documentation.
Using the current implementation:
- Users had to list every single path manually as a string.
- There was no support for wildcards or pattern-based filtering.
- Managing long lists of excluded paths was error-prone and tedious.

### ✨ The Solution
I have updated the `toOpenAPISchema` logic to handle both strings and `RegExp` objects within the `exclude.paths` array.
1. **Pattern Extraction**: The plugin now filters the exclusion list to pre-compute all provided `RegExp` instances.
2. **Type Safety**: Implemented a TypeScript **type predicate** (`path is RegExp`) to ensure explicit narrowing and type safety when testing patterns.
3. **Dynamic Testing**: During schema generation, each route is checked against these patterns using `.test(route.path)`.
4. **Compatibility**: This change is fully backward compatible with the existing string-based exclusion logic.

### 📝 Technical Changes
- **`src/openapi.ts`**: 
    - Added `ignorePatterns` with explicit `RegExp[]` typing.
    - Used a type predicate for the `.filter()` call to correctly narrow types.
    - Integrated `pattern.test(route.path)` logic inside the route mapping loop.

### 📖 Example Usage
Now you can easily exclude all routes starting with a specific prefix:

```typescript
app.use(
  openapi({
    exclude: {
      paths: [
        /^\/v1/,         // Excludes all routes starting with /v1
        /^\/admin/,      // Excludes all admin routes
        '/health-check'  // Still supports exact strings
      ]
    }
  })
)
```