### PR TITLE
feat: add headers from `withHeaders` to OpenAPI

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -11,7 +11,6 @@ import type { OpenAPIV3 } from 'openapi-types'
 import {
 	Kind,
 	TAnySchema,
-	type TProperties,
 	type TObject
 } from '@sinclair/typebox'
 
@@ -1133,7 +1132,29 @@ export function toOpenAPISchema(
 	} satisfies Pick<OpenAPIV3.Document, 'paths' | 'components'>
 }
 
-export const withHeaders = (schema: TSchema, headers: TProperties) =>
-	Object.assign(schema, {
-		headers: headers
+type ResponseHeaderSchemas = Record<
+	string,
+	Exclude<InputSchema['headers'], undefined>
+>
+
+export const withHeaders = <
+	S extends Exclude<InputSchema['body'], string | undefined>,
+	H extends ResponseHeaderSchemas
+>(
+	schema: S,
+	headers: H
+) => {
+	const clone = Object.create(
+		Object.getPrototypeOf(schema),
+		Object.getOwnPropertyDescriptors(schema)
+	) as S & { headers: H }
+
+	Object.defineProperty(clone, 'headers', {
+		value: headers,
+		enumerable: true,
+		configurable: true,
+		writable: true
 	})
+
+	return clone
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -668,6 +668,76 @@ export const enumToOpenApi = <
 	return schema as T
 }
 
+const toResponseHeaders = (
+	schema: InputSchema['body'],
+	vendors?: MapJsonSchema
+): Record<string, OpenAPIV3.HeaderObject> | undefined => {
+	if (
+		!schema ||
+		typeof schema === 'string' ||
+		!('headers' in schema) ||
+		!schema.headers
+	)
+		return
+
+	const entries = Object.entries(
+		schema.headers as Record<string, InputSchema['headers']>
+	)
+		.map(
+			([name, hs]) =>
+				[
+					name,
+					{ schema: unwrapSchema(hs as any, vendors, 'output') }
+				] as const
+		)
+		.filter(([, v]) => v.schema)
+
+	return entries.length ? Object.fromEntries(entries) : undefined
+}
+
+const stripHeaders = (
+	schema: OpenAPIV3.SchemaObject & { headers?: unknown }
+): OpenAPIV3.SchemaObject => {
+	const { headers, ...rest } = schema
+	return rest
+}
+
+const VOID_TYPES = new Set(['void', 'null', 'undefined'])
+const PLAIN_TYPES = new Set(['string', 'number', 'integer', 'boolean'])
+
+const toResponseContent = (
+	schema: OpenAPIV3.SchemaObject,
+	type: string | undefined,
+	description: string | undefined
+) =>
+	VOID_TYPES.has(type!)
+		? ({ type, description } as any)
+		: PLAIN_TYPES.has(type!)
+			? { 'text/plain': { schema } }
+			: { 'application/json': { schema } }
+
+const toResponseObject = (
+	schema: InputSchema['body'],
+	status: string,
+	definitions: Record<string, unknown>,
+	vendors?: MapJsonSchema
+): OpenAPIV3.ResponseObject | undefined => {
+	const response = unwrapSchema(schema, vendors, 'output')
+	if (!response) return
+
+	const responseSchema = stripHeaders(response)
+
+	// @ts-ignore Must exclude $ref from root options
+	const { type, description } = unwrapReference(responseSchema, definitions)
+	const headers = toResponseHeaders(schema, vendors)
+
+	return {
+		description: description ?? `Response for status ${status}`,
+		...(headers ? { headers } : {}),
+		content: toResponseContent(responseSchema, type, description)
+	}
+}
+
 /**
  * Converts Elysia routes to OpenAPI 3.0.3 paths schema
  * @param routes Array of Elysia route objects
@@ -986,78 +1056,24 @@ export function toOpenAPISchema(
 				!(hooks.response as any)['~standard']
 			) {
 				for (let [status, schema] of Object.entries(hooks.response)) {
-					const response = unwrapSchema(schema, vendors, 'output')
+					const response = toResponseObject(
+						schema,
+						status,
+						definitions,
+						vendors
+					)
 
-					if (!response) continue
-
-					// @ts-ignore Must exclude $ref from root options
-					const { type, description, $ref, ..._options } =
-						unwrapReference(response, definitions)
-
-					operation.responses[status] = {
-						description:
-							description ?? `Response for status ${status}`,
-						content:
-							type === 'void' ||
-							type === 'null' ||
-							type === 'undefined'
-								? ({ type, description } as any)
-								: type === 'string' ||
-									  type === 'number' ||
-									  type === 'integer' ||
-									  type === 'boolean'
-									? {
-											'text/plain': {
-												schema: response
-											}
-										}
-									: {
-											'application/json': {
-												schema: response
-											}
-										}
-					}
+					if (response) operation.responses[status] = response
 				}
 			} else {
-				const response = unwrapSchema(
-					hooks.response as any,
-					vendors,
-					'output'
+				const response = toResponseObject(
+					hooks.response as InputSchema['body'],
+					'200',
+					definitions,
+					vendors
 				)
 
-				if (response) {
-					// @ts-ignore
-					const {
-						type: _type,
-						description,
-						...options
-					} = unwrapReference(response, definitions)
-					const type = _type as string | undefined
-
-					// It's a single schema, default to 200
-					operation.responses['200'] = {
-						description: description ?? `Response for status 200`,
-						content:
-							type === 'void' ||
-							type === 'null' ||
-							type === 'undefined'
-								? ({ type, description } as any)
-								: type === 'string' ||
-									  type === 'number' ||
-									  type === 'integer' ||
-									  type === 'boolean'
-									? {
-											'text/plain': {
-												schema: response
-											}
-										}
-									: {
-											'application/json': {
-												schema: response
-											}
-										}
-					}
-				}
+				if (response) operation.responses['200'] = response
 			}
 		}
 

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -1405,4 +1405,168 @@ describe('OpenAPI > toOpenAPISchema', () => {
 			}
 		})
 	})
+
+	it('does not leak headers across reused typebox response schemas', () => {
+		const response = t.Object({ name: t.String() })
+
+		const app = new Elysia()
+			.get('/with-headers', () => ({ name: 'Lilith' }) as const, {
+				response: withHeaders(response, {
+					'x-rate-limit': t.Number()
+				})
+			})
+			.get('/without-headers', () => ({ name: 'Lilith' }) as const, {
+				response
+			})
+
+		is(app, {
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/with-headers': {
+					get: {
+						operationId: 'getWith-headers',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								headers: {
+									'x-rate-limit': {
+										schema: {
+											type: 'number'
+										}
+									}
+								},
+								content: {
+									'application/json': {
+										schema: {
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				'/without-headers': {
+					get: {
+						operationId: 'getWithout-headers',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								content: {
+									'application/json': {
+										schema: {
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	})
+
+	it('does not leak headers across reused standard response schemas', () => {
+		const response = z.object({ name: z.string() })
+
+		const app = new Elysia()
+			.get('/with-headers', () => ({ name: 'Lilith' }) as const, {
+				response: withHeaders(response, {
+					'x-rate-limit': t.Number()
+				})
+			})
+			.get('/without-headers', () => ({ name: 'Lilith' }) as const, {
+				response
+			})
+
+		expect(
+			JSON.parse(
+				JSON.stringify(
+					toOpenAPISchema(app, undefined, undefined, {
+						zod: z.toJSONSchema
+					})
+				)
+			)
+		).toEqual({
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/with-headers': {
+					get: {
+						operationId: 'getWith-headers',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								headers: {
+									'x-rate-limit': {
+										schema: {
+											type: 'number'
+										}
+									}
+								},
+								content: {
+									'application/json': {
+										schema: {
+											$schema:
+												'https://json-schema.org/draft/2020-12/schema',
+											additionalProperties: false,
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				'/without-headers': {
+					get: {
+						operationId: 'getWithout-headers',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								content: {
+									'application/json': {
+										schema: {
+											$schema:
+												'https://json-schema.org/draft/2020-12/schema',
+											additionalProperties: false,
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	})
 })

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test'
 import { AnyElysia, Elysia, t } from 'elysia'
 
-import { toOpenAPISchema } from '../../src/openapi'
+import { toOpenAPISchema, withHeaders } from '../../src/openapi'
 import { z } from 'zod'
 
 const is = <T extends AnyElysia>(
@@ -1271,6 +1271,135 @@ describe('OpenAPI > toOpenAPISchema', () => {
 								}
 							}
 						]
+					}
+				}
+			}
+		})
+	})
+
+	it('handle withHeaders on single response', () => {
+		const app = new Elysia().get(
+			'/user',
+			() => ({ name: 'Lilith' }) as const,
+			{
+				response: withHeaders(
+					t.Object({ name: t.String() }),
+					{
+						'x-rate-limit': t.Number(),
+						'x-request-id': t.String()
+					}
+				)
+			}
+		)
+
+		is(app, {
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/user': {
+					get: {
+						operationId: 'getUser',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								headers: {
+									'x-rate-limit': {
+										schema: {
+											type: 'number'
+										}
+									},
+									'x-request-id': {
+										schema: {
+											type: 'string'
+										}
+									}
+								},
+								content: {
+									'application/json': {
+										schema: {
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	})
+
+	it('handle withHeaders on multiple response status', () => {
+		const app = new Elysia().get(
+			'/user',
+			() => ({ name: 'Lilith' }) as const,
+			{
+				response: {
+					200: withHeaders(
+						t.Object({ name: t.String() }),
+						{ 'x-rate-limit': t.Number() }
+					),
+					404: t.Object({ error: t.String() })
+				}
+			}
+		)
+
+		is(app, {
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/user': {
+					get: {
+						operationId: 'getUser',
+						responses: {
+							'200': {
+								description: 'Response for status 200',
+								headers: {
+									'x-rate-limit': {
+										schema: {
+											type: 'number'
+										}
+									}
+								},
+								content: {
+									'application/json': {
+										schema: {
+											properties: {
+												name: {
+													type: 'string'
+												}
+											},
+											required: ['name'],
+											type: 'object'
+										}
+									}
+								}
+							},
+							'404': {
+								description: 'Response for status 404',
+								content: {
+									'application/json': {
+										schema: {
+											properties: {
+												error: {
+													type: 'string'
+												}
+											},
+											required: ['error'],
+											type: 'object'
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
I was surprised to see in the docs that `withHeaders` is just decoration for now, ie the headers don't actually get added to the OpenAPI schema. 

With this PR they get picked up.

Verification:
- Added some tests
- Tested in a production Elysia app, the headers get added correctly
- (But I'm not familiar enough with the codebase to feel confident that nothing else is being broken)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom response headers in generated OpenAPI specifications.

* **Refactor**
  * Centralized and simplified response/content/header generation for more consistent OpenAPI output.
  * Updated the exported helper for attaching headers to schemas to better preserve typing and metadata.

* **Tests**
  * Added tests ensuring response headers are emitted correctly and do not leak across routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->