### PR TITLE
fix(openapi): document arrayBuffer bodies

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -936,6 +936,13 @@ export function toOpenAPISchema(
 									schema: body
 								}
 								continue
+
+							case 'arrayBuffer':
+							case 'application/octet-stream':
+								content['application/octet-stream'] = {
+									schema: body
+								}
+								continue
 						}
 					}
 

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -229,6 +229,39 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		})
 	})
 
+	it('handle arrayBuffer request body', () => {
+		const app = new Elysia().post('/upload', () => 'ok', {
+			parse: 'arrayBuffer',
+			body: t.Any({
+				description: 'Binary file data'
+			})
+		})
+
+		is(app, {
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/upload': {
+					post: {
+						operationId: 'postUpload',
+						requestBody: {
+							description: 'Binary file data',
+							content: {
+								'application/octet-stream': {
+									schema: {
+										description: 'Binary file data'
+									}
+								}
+							},
+							required: true
+						}
+					}
+				}
+			}
+		})
+	})
+
 	it('handle response', () => {
 		const app = new Elysia().get(
 			'/user',


### PR DESCRIPTION
Closes elysiajs/elysia#1825

## Problem

Routes using `parse: "arrayBuffer"` with a body schema produced an OpenAPI request body with an empty `content` object:

```json
{
  "requestBody": {
    "content": {}
  }
}
```

That makes OpenAPI clients infer the request body as missing or `undefined`.

## Fix

Map `arrayBuffer` request parsers to `application/octet-stream` when generating request body content. The same mapping is also used when the parser is already declared as `application/octet-stream`.

## Tests

Added a regression in `test/openapi/to-openapi-schema.test.ts` for:

- `parse: "arrayBuffer"`
- binary body schema description
- generated `requestBody.content["application/octet-stream"]`

Verification run:

- `bun test test/openapi/to-openapi-schema.test.ts`
- `git diff --check`
- `bun run build`
- `PATH="$PWD/node_modules/.bin:$PATH" bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binary request payloads in OpenAPI schema generation. Binary data is now properly documented with application/octet-stream content type, enabling accurate API documentation for endpoints that accept binary data.

* **Tests**
  * Added test coverage for binary request payload handling in OpenAPI conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->