### PR TITLE
fix(gen): preserve fromTypes compiler defaults

### DIFF
--- a/src/gen/index.ts
+++ b/src/gen/index.ts
@@ -260,6 +260,7 @@ export const fromTypes =
 					: ''
 
 				let distDir = join(tmpRoot, 'dist')
+				let rootDir = projectRoot
 
 				// Convert Windows path to Unix for TypeScript CLI
 				if (
@@ -269,27 +270,28 @@ export const fromTypes =
 					extendsRef = extendsRef.replace(/\\/g, '/')
 					src = src.replace(/\\/g, '/')
 					distDir = distDir.replace(/\\/g, '/')
+					rootDir = rootDir.replace(/\\/g, '/')
+				}
+
+				const resolvedCompilerOptions = {
+					lib: ['ESNext'],
+					module: 'ESNext',
+					noEmit: false,
+					declaration: true,
+					emitDeclarationOnly: true,
+					moduleResolution: 'bundler',
+					skipLibCheck: true,
+					skipDefaultLibCheck: true,
+					rootDir,
+					outDir: distDir,
+					...compilerOptions
 				}
 
 				fs.writeFileSync(
 					join(tmpRoot, 'tsconfig.json'),
 					`{
 	${extendsRef}
-	"compilerOptions": ${
-		compilerOptions
-			? JSON.stringify(compilerOptions)
-			: `{
-	"lib": ["ESNext"],
-	"module": "ESNext",
-	"noEmit": false,
-	"declaration": true,
-	"emitDeclarationOnly": true,
-	"moduleResolution": "bundler",
-	"skipLibCheck": true,
-	"skipDefaultLibCheck": true,
-	"outDir": "${distDir}"
-}`
-	},
+	"compilerOptions": ${JSON.stringify(resolvedCompilerOptions)},
 	"include": ["${src}"]
 }`
 				)

--- a/test/gen/index.test.ts
+++ b/test/gen/index.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { declarationToJSONSchema, fromTypes } from '../../src/gen'
 
@@ -647,5 +650,42 @@ describe('Gen > Type Gen', () => {
 				}
 			}
 		})
+	})
+
+	it('merge compilerOptions override with declaration defaults', () => {
+		const tmpRoot = mkdtempSync(join(tmpdir(), 'elysia-openapi-'))
+
+		try {
+			const reference = fromTypes('test/gen/sample.ts', {
+				tmpRoot,
+				debug: true,
+				silent: true,
+				compilerOptions: {
+					strict: true
+				}
+			})()
+
+			expect(serializable(reference)!).toBeDefined()
+
+			const tsconfig = JSON.parse(
+				readFileSync(join(tmpRoot, 'tsconfig.json'), 'utf8')
+			)
+
+			expect(tsconfig.compilerOptions).toMatchObject({
+				lib: ['ESNext'],
+				module: 'ESNext',
+				noEmit: false,
+				declaration: true,
+				emitDeclarationOnly: true,
+				moduleResolution: 'bundler',
+				skipLibCheck: true,
+				skipDefaultLibCheck: true,
+				rootDir: process.cwd(),
+				outDir: join(tmpRoot, 'dist'),
+				strict: true
+			})
+		} finally {
+			rmSync(tmpRoot, { recursive: true, force: true })
+		}
 	})
 })


### PR DESCRIPTION
## Summary
- preserve declaration compiler defaults when `fromTypes(..., { compilerOptions })` is used
- set the generated tsconfig `rootDir` to the project root and keep declaration output inside `tmpRoot/dist`
- add regression coverage for a partial `compilerOptions` override

## Why
`compilerOptions` previously replaced the whole generated block. Passing an override such as `{ strict: true }` dropped required declaration emit settings like `declaration`, `emitDeclarationOnly`, `noEmit: false`, and `outDir`. With newer TypeScript behavior, missing `rootDir`/`outDir` can also let generated `.d.ts` files appear beside project sources instead of staying in the temporary directory.

## Tests
- `PATH="$PWD/node_modules/.bin:$PATH" bun test test/gen/index.test.ts --timeout 20000`
- `git diff --check`
- `bun run build`
- `PATH="$PWD/node_modules/.bin:$PATH" bun run test`

Closes elysiajs/elysia#1855
