### PR TITLE
Fix null vs nullable, and add a OpenAPI version switch, starting with v3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ Then go to `http://localhost:3000/openapi`.
 @default true
 Enable/Disable the plugin
 
+## openapiVersion
+
+@default '3.1.2'
+
+OpenAPI document version to emit. Supports OpenAPI `3.0.x` and `3.1.x`.
+
 ## documentation
 
 OpenAPI documentation information
 
-@see https://spec.openapis.org/oas/v3.0.3.html
+@see https://spec.openapis.org/oas/latest.html
 
 ## exclude
 

--- a/src/gen/index.ts
+++ b/src/gen/index.ts
@@ -260,6 +260,7 @@ export const fromTypes =
 					: ''
 
 				let distDir = join(tmpRoot, 'dist')
+				let rootDir = projectRoot
 
 				// Convert Windows path to Unix for TypeScript CLI
 				if (
@@ -269,6 +270,7 @@ export const fromTypes =
 					extendsRef = extendsRef.replace(/\\/g, '/')
 					src = src.replace(/\\/g, '/')
 					distDir = distDir.replace(/\\/g, '/')
+					rootDir = rootDir.replace(/\\/g, '/')
 				}
 
 				fs.writeFileSync(
@@ -287,6 +289,7 @@ export const fromTypes =
 	"moduleResolution": "bundler",
 	"skipLibCheck": true,
 	"skipDefaultLibCheck": true,
+	"rootDir": "${rootDir}",
 	"outDir": "${distDir}"
 }`
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export const openapi = <
 		paths,
 		components: { schemas }
 	}: ReturnType<typeof toOpenAPISchema>): OpenAPIDocument => {
-		return (cachedSchema = {
+		const schema: OpenAPIDocument = {
 			...documentation,
 			openapi: effectiveOpenAPIVersion as OpenAPIVersion,
 			tags: !exclude?.tags
@@ -122,7 +122,9 @@ export const openapi = <
 					...(documentation.components?.schemas as any)
 				}
 			}
-		})
+		}
+
+		return (cachedSchema = schema)
 	}
 
 	const app = new Elysia({ name: '@elysiajs/openapi' })
@@ -158,7 +160,8 @@ export const openapi = <
 														app,
 														exclude,
 														references,
-														mapJsonSchema
+														mapJsonSchema,
+														effectiveOpenAPIVersion
 													)
 												)
 									)
@@ -189,7 +192,13 @@ export const openapi = <
 			totalRoutes = app.routes.length
 
 			return toFullSchema(
-				toOpenAPISchema(app, exclude, references, mapJsonSchema)
+				toOpenAPISchema(
+					app,
+					exclude,
+					references,
+					mapJsonSchema,
+					effectiveOpenAPIVersion
+				)
 			)
 		},
 		{

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,32 @@ import { ScalarRender } from './scalar'
 
 import { toOpenAPISchema } from './openapi'
 
-import type { OpenAPIV3 } from 'openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
-import type { ElysiaOpenAPIConfig } from './types'
+import type { ElysiaOpenAPIConfig, OpenAPIVersion } from './types'
+
+type OpenAPIDocument = {
+	openapi: OpenAPIVersion
+	[key: string]: unknown
+}
+
+const DEFAULT_OPENAPI_VERSION: OpenAPIVersion = '3.1.2'
+const OPENAPI_VERSION_REGEX = /^3\.(0|1)\.\d+$/
+
+const normalizeOpenAPIVersion = (
+	version: string | undefined
+): OpenAPIVersion => {
+	if (!version) return DEFAULT_OPENAPI_VERSION
+
+	if (!OPENAPI_VERSION_REGEX.test(version)) {
+		console.warn(
+			`[@elysiajs/openapi] Invalid openapiVersion "${version}". Expected 3.0.x or 3.1.x. Falling back to ${DEFAULT_OPENAPI_VERSION}.`
+		)
+
+		return DEFAULT_OPENAPI_VERSION
+	}
+
+	return version as OpenAPIVersion
+}
 
 function isCloudflareWorker() {
 	try {
@@ -45,6 +68,7 @@ export const openapi = <
 	path = '/openapi' as Path,
 	provider = 'scalar',
 	specPath = `${path}/json`,
+	openapiVersion = DEFAULT_OPENAPI_VERSION,
 	documentation = {},
 	exclude,
 	swagger,
@@ -63,17 +87,19 @@ export const openapi = <
 	}
 
 	const relativePath = specPath.startsWith('/') ? specPath.slice(1) : specPath
+	const effectiveOpenAPIVersion: OpenAPIVersion =
+		normalizeOpenAPIVersion(openapiVersion)
 
 	let totalRoutes = 0
-	let cachedSchema: OpenAPIV3.Document | undefined
+	let cachedSchema: OpenAPIDocument | undefined
 
 	const toFullSchema = ({
 		paths,
 		components: { schemas }
-	}: ReturnType<typeof toOpenAPISchema>): OpenAPIV3.Document => {
+	}: ReturnType<typeof toOpenAPISchema>): OpenAPIDocument => {
 		return (cachedSchema = {
-			openapi: '3.0.3',
 			...documentation,
+			openapi: effectiveOpenAPIVersion as OpenAPIVersion,
 			tags: !exclude?.tags
 				? documentation.tags
 				: documentation.tags?.filter(
@@ -156,7 +182,7 @@ export const openapi = <
 		)
 	}).get(
 		specPath,
-		function openAPISchema(): OpenAPIV3.Document {
+		function openAPISchema(): OpenAPIDocument {
 			if (totalRoutes === app.routes.length && cachedSchema)
 				return cachedSchema
 
@@ -182,6 +208,6 @@ export const openapi = <
 
 export { fromTypes } from './gen'
 export { toOpenAPISchema, withHeaders } from './openapi'
-export type { ElysiaOpenAPIConfig }
+export type { ElysiaOpenAPIConfig, OpenAPIVersion } from './types'
 
 export default openapi

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -25,11 +25,8 @@ import type {
 export const capitalize = (word: string) =>
 	word.charAt(0).toUpperCase() + word.slice(1)
 
-const toRef = (name: string) => t.Ref(
-	name.startsWith('#/')
-		? name
-		: `#/components/schemas/${name}`
-)
+const toRef = (name: string) =>
+	t.Ref(name.startsWith('#/') ? name : `#/components/schemas/${name}`)
 
 const toOperationId = (method: string, paths: string) => {
 	let operationId = method.toLowerCase()
@@ -540,9 +537,12 @@ export const unwrapSchema = (
 		// @ts-ignore
 		if (schema['~standard']?.jsonSchema?.[io])
 			// @ts-ignore
-			return enumToOpenApi(schema['~standard'].jsonSchema[io]({
-				target: 'draft-2020-12'
-			}))
+			return enumToOpenApi(
+				// @ts-ignore
+				schema['~standard'].jsonSchema[io]({
+					target: 'draft-2020-12'
+				})
+			)
 
 		switch (vendor) {
 			case 'zod':
@@ -980,6 +980,7 @@ export function toOpenAPISchema(
 
 			if (
 				typeof hooks.response === 'object' &&
+				!(Kind in (hooks.response as object)) &&
 				// TypeBox
 				!(hooks.response as TSchema).type &&
 				!(hooks.response as TSchema).$ref &&

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -637,6 +637,28 @@ export const unwrapSchema = (
 	}
 }
 
+const SCHEMA_OBJECT_MAP_KEYS = new Set([
+	'properties',
+	'patternProperties',
+	'$defs',
+	'definitions',
+	'dependentSchemas'
+])
+
+const SCHEMA_ARRAY_KEYS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems'])
+
+const SCHEMA_OR_BOOL_KEYS = new Set([
+	'items',
+	'additionalProperties',
+	'unevaluatedProperties',
+	'contains',
+	'not',
+	'if',
+	'then',
+	'else',
+	'propertyNames'
+])
+
 const normalizeNullableSchemaForOAS30 = (schema: unknown): unknown => {
 	if (!schema || typeof schema !== 'object') return schema
 
@@ -644,9 +666,6 @@ const normalizeNullableSchemaForOAS30 = (schema: unknown): unknown => {
 		return schema.map((item) => normalizeNullableSchemaForOAS30(item))
 
 	const normalized = { ...(schema as Record<string, unknown>) }
-
-	for (const [key, value] of Object.entries(normalized))
-		normalized[key] = normalizeNullableSchemaForOAS30(value)
 
 	if (normalized.type === 'null') {
 		delete normalized.type
@@ -710,6 +729,51 @@ const normalizeNullableSchemaForOAS30 = (schema: unknown): unknown => {
 		}
 	}
 
+	for (const [key, value] of Object.entries(normalized)) {
+		if (SCHEMA_OBJECT_MAP_KEYS.has(key)) {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] = normalizeNullableSchemaForOAS30(nestedValue)
+				normalized[key] = next
+			}
+			continue
+		}
+
+		if (SCHEMA_ARRAY_KEYS.has(key)) {
+			if (Array.isArray(value))
+				normalized[key] = value.map((item) =>
+					normalizeNullableSchemaForOAS30(item)
+				)
+			continue
+		}
+
+		if (SCHEMA_OR_BOOL_KEYS.has(key)) {
+			if (value && typeof value === 'object') {
+				if (Array.isArray(value))
+					normalized[key] = value.map((item) =>
+						normalizeNullableSchemaForOAS30(item)
+					)
+				else normalized[key] = normalizeNullableSchemaForOAS30(value)
+			}
+			continue
+		}
+
+		if (key === 'dependencies') {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] =
+						nestedValue &&
+						typeof nestedValue === 'object' &&
+						!Array.isArray(nestedValue)
+							? normalizeNullableSchemaForOAS30(nestedValue)
+							: nestedValue
+				normalized[key] = next
+			}
+		}
+	}
+
 	return normalized
 }
 
@@ -720,9 +784,6 @@ const normalizeNullableSchemaForOAS31 = (schema: unknown): unknown => {
 		return schema.map((item) => normalizeNullableSchemaForOAS31(item))
 
 	const normalized = { ...(schema as Record<string, unknown>) }
-
-	for (const [key, value] of Object.entries(normalized))
-		normalized[key] = normalizeNullableSchemaForOAS31(value)
 
 	const rewriteNullUnion = (key: 'anyOf' | 'oneOf') => {
 		if (!Array.isArray(normalized[key])) return
@@ -746,6 +807,51 @@ const normalizeNullableSchemaForOAS31 = (schema: unknown): unknown => {
 
 	rewriteNullUnion('anyOf')
 	rewriteNullUnion('oneOf')
+
+	for (const [key, value] of Object.entries(normalized)) {
+		if (SCHEMA_OBJECT_MAP_KEYS.has(key)) {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] = normalizeNullableSchemaForOAS31(nestedValue)
+				normalized[key] = next
+			}
+			continue
+		}
+
+		if (SCHEMA_ARRAY_KEYS.has(key)) {
+			if (Array.isArray(value))
+				normalized[key] = value.map((item) =>
+					normalizeNullableSchemaForOAS31(item)
+				)
+			continue
+		}
+
+		if (SCHEMA_OR_BOOL_KEYS.has(key)) {
+			if (value && typeof value === 'object') {
+				if (Array.isArray(value))
+					normalized[key] = value.map((item) =>
+						normalizeNullableSchemaForOAS31(item)
+					)
+				else normalized[key] = normalizeNullableSchemaForOAS31(value)
+			}
+			continue
+		}
+
+		if (key === 'dependencies') {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] =
+						nestedValue &&
+						typeof nestedValue === 'object' &&
+						!Array.isArray(nestedValue)
+							? normalizeNullableSchemaForOAS31(nestedValue)
+							: nestedValue
+				normalized[key] = next
+			}
+		}
+	}
 
 	return normalized
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -19,7 +19,8 @@ import type {
 	AdditionalReference,
 	AdditionalReferences,
 	ElysiaOpenAPIConfig,
-	MapJsonSchema
+	MapJsonSchema,
+	OpenAPIVersion
 } from './types'
 
 export const capitalize = (word: string) =>
@@ -507,12 +508,17 @@ const unwrapReference = <T extends OpenAPIV3.SchemaObject | undefined>(
 export const unwrapSchema = (
 	schema: InputSchema['body'],
 	mapJsonSchema?: MapJsonSchema,
-	io: 'input' | 'output' = 'input'
+	io: 'input' | 'output' = 'input',
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ): OpenAPIV3.SchemaObject | undefined => {
 	if (!schema) return
 
 	if (typeof schema === 'string') schema = toRef(schema)
-	if (Kind in schema) return enumToOpenApi(schema)
+	if (Kind in schema)
+		return normalizeSchemaForOpenAPIVersion(
+			enumToOpenApi(schema),
+			openapiVersion
+		)
 
 	// Already unwrapped by merging standalone validators
 	if (
@@ -520,7 +526,10 @@ export const unwrapSchema = (
 		// @ts-ignore
 		(schema.$schema || schema.type || schema.properties || schema.items)
 	)
-		return schema as OpenAPIV3.SchemaObject
+		return normalizeSchemaForOpenAPIVersion(
+			schema as OpenAPIV3.SchemaObject,
+			openapiVersion
+		)
 
 	if (!schema?.['~standard']) return
 
@@ -528,20 +537,30 @@ export const unwrapSchema = (
 	const vendor = schema['~standard'].vendor
 
 	try {
+		const jsonSchemaTarget = openapiVersion.startsWith('3.0.')
+			? 'draft-07'
+			: 'draft-2020-12'
+
 		if (
 			mapJsonSchema?.[vendor] &&
 			typeof mapJsonSchema[vendor] === 'function'
 		)
-			return enumToOpenApi(mapJsonSchema[vendor](schema))
+			return normalizeSchemaForOpenAPIVersion(
+				enumToOpenApi(mapJsonSchema[vendor](schema)),
+				openapiVersion
+			)
 
 		// @ts-ignore
 		if (schema['~standard']?.jsonSchema?.[io])
 			// @ts-ignore
-			return enumToOpenApi(
+			return normalizeSchemaForOpenAPIVersion(
+				enumToOpenApi(
 				// @ts-ignore
 				schema['~standard'].jsonSchema[io]({
-					target: 'draft-2020-12'
+					target: jsonSchemaTarget
 				})
+			),
+			openapiVersion
 			)
 
 		switch (vendor) {
@@ -600,15 +619,154 @@ export const unwrapSchema = (
 
 		if (vendor === 'arktype')
 			// @ts-ignore
-			return enumToOpenApi(schema?.toJsonSchema?.())
+			return normalizeSchemaForOpenAPIVersion(
+				// @ts-ignore
+				enumToOpenApi(schema?.toJsonSchema?.()),
+				openapiVersion
+			)
 
-		return enumToOpenApi(
-			// @ts-ignore
-			schema.toJSONSchema?.() ?? schema?.toJsonSchema?.()
+		return normalizeSchemaForOpenAPIVersion(
+			enumToOpenApi(
+				// @ts-ignore
+				schema.toJSONSchema?.() ?? schema?.toJsonSchema?.()
+			),
+			openapiVersion
 		)
 	} catch (error) {
 		console.warn(error)
 	}
+}
+
+const normalizeNullableSchemaForOAS30 = (schema: unknown): unknown => {
+	if (!schema || typeof schema !== 'object') return schema
+
+	if (Array.isArray(schema))
+		return schema.map((item) => normalizeNullableSchemaForOAS30(item))
+
+	const normalized = { ...(schema as Record<string, unknown>) }
+
+	for (const [key, value] of Object.entries(normalized))
+		normalized[key] = normalizeNullableSchemaForOAS30(value)
+
+	if (normalized.type === 'null') {
+		delete normalized.type
+		normalized.nullable = true
+		return normalized
+	}
+
+	if (Array.isArray(normalized.type) && normalized.type.includes('null')) {
+		const nonNullTypes = normalized.type.filter(
+			(type) => type !== 'null'
+		) as string[]
+
+		normalized.nullable = true
+
+		if (nonNullTypes.length === 1) normalized.type = nonNullTypes[0]
+		else if (nonNullTypes.length > 1) normalized.type = nonNullTypes
+		else delete normalized.type
+
+		return normalized
+	}
+
+	if (Array.isArray(normalized.anyOf)) {
+		const entries = normalized.anyOf as Array<Record<string, unknown>>
+		const nonNullEntries = entries.filter((entry) => {
+			const isNormalizedNullEntry =
+				entry?.nullable === true &&
+				!('type' in entry) &&
+				Object.keys(entry).length === 1
+
+			return entry?.type !== 'null' && !isNormalizedNullEntry
+		})
+
+		if (nonNullEntries.length !== entries.length) {
+			normalized.nullable = true
+
+			if (nonNullEntries.length === 1) {
+				delete normalized.anyOf
+				Object.assign(normalized, nonNullEntries[0])
+			} else normalized.anyOf = nonNullEntries
+		}
+	}
+
+	if (Array.isArray(normalized.oneOf)) {
+		const entries = normalized.oneOf as Array<Record<string, unknown>>
+		const nonNullEntries = entries.filter((entry) => {
+			const isNormalizedNullEntry =
+				entry?.nullable === true &&
+				!('type' in entry) &&
+				Object.keys(entry).length === 1
+
+			return entry?.type !== 'null' && !isNormalizedNullEntry
+		})
+
+		if (nonNullEntries.length !== entries.length) {
+			normalized.nullable = true
+
+			if (nonNullEntries.length === 1) {
+				delete normalized.oneOf
+				Object.assign(normalized, nonNullEntries[0])
+			} else normalized.oneOf = nonNullEntries
+		}
+	}
+
+	return normalized
+}
+
+const normalizeNullableSchemaForOAS31 = (schema: unknown): unknown => {
+	if (!schema || typeof schema !== 'object') return schema
+
+	if (Array.isArray(schema))
+		return schema.map((item) => normalizeNullableSchemaForOAS31(item))
+
+	const normalized = { ...(schema as Record<string, unknown>) }
+
+	for (const [key, value] of Object.entries(normalized))
+		normalized[key] = normalizeNullableSchemaForOAS31(value)
+
+	const rewriteNullUnion = (key: 'anyOf' | 'oneOf') => {
+		if (!Array.isArray(normalized[key])) return
+
+		const entries = normalized[key] as Array<Record<string, unknown>>
+		const nullEntries = entries.filter((entry) => entry?.type === 'null')
+		if (nullEntries.length === 0) return
+
+		const nonNullEntries = entries.filter((entry) => entry?.type !== 'null')
+		if (nonNullEntries.length !== 1) return
+
+		const [nonNull] = nonNullEntries
+		const nonNullType = nonNull?.type
+
+		if (typeof nonNullType !== 'string') return
+
+		delete normalized[key]
+		Object.assign(normalized, nonNull)
+		normalized.type = [nonNullType, 'null']
+	}
+
+	rewriteNullUnion('anyOf')
+	rewriteNullUnion('oneOf')
+
+	return normalized
+}
+
+export const nullToOpenApi = <T>(
+	schema: T,
+	openapiVersion: OpenAPIVersion
+): T => {
+	if (!schema) return schema
+
+	if (openapiVersion.startsWith('3.0.'))
+		return normalizeNullableSchemaForOAS30(schema) as T
+
+	return normalizeNullableSchemaForOAS31(schema) as T
+}
+
+const normalizeSchemaForOpenAPIVersion = <T>(
+	schema: T,
+	openapiVersion: OpenAPIVersion
+): T => {
+	return nullToOpenApi(schema, openapiVersion)
 }
 
 /**
@@ -677,7 +835,8 @@ export function toOpenAPISchema(
 	app: AnyElysia,
 	exclude?: ElysiaOpenAPIConfig['exclude'],
 	references?: AdditionalReferences,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ) {
 	let {
 		methods: excludeMethods = ['options'],
@@ -803,7 +962,7 @@ export function toOpenAPISchema(
 		// Handle path parameters
 		if (hooks.params) {
 			const params = unwrapReference(
-				unwrapSchema(hooks.params, vendors),
+				unwrapSchema(hooks.params, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -831,7 +990,7 @@ export function toOpenAPISchema(
 		// Handle query parameters
 		if (hooks.query) {
 			const query = unwrapReference(
-				unwrapSchema(hooks.query, vendors),
+				unwrapSchema(hooks.query, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -850,7 +1009,7 @@ export function toOpenAPISchema(
 		// Handle header parameters
 		if (hooks.headers) {
 			const headers = unwrapReference(
-				unwrapSchema(hooks.headers, vendors),
+				unwrapSchema(hooks.headers, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -869,7 +1028,7 @@ export function toOpenAPISchema(
 		// Handle cookie parameters
 		if (hooks.cookie) {
 			const cookie = unwrapReference(
-				unwrapSchema(hooks.cookie, vendors),
+				unwrapSchema(hooks.cookie, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -890,7 +1049,12 @@ export function toOpenAPISchema(
 
 		// Handle request body
 		if (hooks.body && method !== 'get' && method !== 'head') {
-			const body = unwrapSchema(hooks.body, vendors)
+			const body = unwrapSchema(
+				hooks.body,
+				vendors,
+				'input',
+				openapiVersion
+			)
 
 			if (body) {
 				// @ts-ignore
@@ -987,7 +1151,12 @@ export function toOpenAPISchema(
 				!(hooks.response as any)['~standard']
 			) {
 				for (let [status, schema] of Object.entries(hooks.response)) {
-					const response = unwrapSchema(schema, vendors, 'output')
+					const response = unwrapSchema(
+						schema,
+						vendors,
+						'output',
+						openapiVersion
+					)
 
 					if (!response) continue
 
@@ -1023,7 +1192,8 @@ export function toOpenAPISchema(
 				const response = unwrapSchema(
 					hooks.response as any,
 					vendors,
-					'output'
+					'output',
+					openapiVersion
 				)
 
 				if (response) {
@@ -1103,7 +1273,12 @@ export function toOpenAPISchema(
 
 	if (definitions)
 		for (const [name, schema] of Object.entries(definitions)) {
-			const jsonSchema = unwrapSchema(schema as any, vendors) as
+			const jsonSchema = unwrapSchema(
+				schema as any,
+				vendors,
+				'input',
+				openapiVersion
+			) as
 				| OpenAPIV3.SchemaObject
 				| undefined
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
 import type { TSchema } from 'elysia'
-import type { OpenAPIV3 } from 'openapi-types'
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
 
 export type OpenAPIProvider = 'scalar' | 'swagger-ui' | null
+export type OpenAPIVersion = `3.0.${number}` | `3.1.${number}`
 
 type MaybeArray<T> = T | T[]
 
@@ -44,12 +45,21 @@ export interface ElysiaOpenAPIConfig<
 	enabled?: Enabled
 
 	/**
+	 * OpenAPI document version to emit
+	 *
+	 * Supports OpenAPI 3.0.x and 3.1.x
+	 *
+	 * @default '3.1.2'
+	 */
+	openapiVersion?: OpenAPIVersion
+
+	/**
 	 * OpenAPI config
 	 *
-	 * @see https://spec.openapis.org/oas/v3.0.3.html
+	 * @see https://spec.openapis.org/oas/latest.html
 	 */
 	documentation?: Omit<
-		Partial<OpenAPIV3.Document>,
+		Partial<OpenAPIV3.Document> & Partial<OpenAPIV3_1.Document>,
 		| 'x-express-openapi-additional-middleware'
 		| 'x-express-openapi-validation-strict'
 	>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,8 +7,8 @@ import { fail } from 'assert'
 
 const req = (path: string) => new Request(`http://localhost${path}`)
 
-describe('Swagger', () => {
-	it('show Swagger page', async () => {
+describe('OpenAPI', () => {
+	it('show OpenAPI page', async () => {
 		const app = new Elysia().use(openapi())
 
 		await app.modules
@@ -23,11 +23,126 @@ describe('Swagger', () => {
 		await app.modules
 
 		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
-		expect(res.openapi).toBe('3.0.3')
+		expect(res.openapi).toBe('3.1.2')
 		await SwaggerParser.validate(res).catch((err) => fail(err))
 	})
 
-	it('use custom Swagger version', async () => {
+	it('emits OpenAPI 3.0.x when configured', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.1'
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.0.1')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('emits OpenAPI 3.1.x when configured', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.1'
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.1')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('passes through jsonSchemaDialect for OpenAPI 3.1', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				documentation: {
+					jsonSchemaDialect:
+						'https://json-schema.org/draft/2020-12/schema'
+				}
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.2')
+		expect(res.jsonSchemaDialect).toBe(
+			'https://json-schema.org/draft/2020-12/schema'
+		)
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('supports OpenAPI 3.1 with swagger-ui provider', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				provider: 'swagger-ui'
+			})
+		)
+
+		await app.modules
+
+		const page = await app.handle(req('/openapi'))
+		expect(page.status).toBe(200)
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.2')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('embeds OpenAPI 3.1 spec in scalar provider when embedSpec is enabled', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				provider: 'scalar',
+				embedSpec: true
+			})
+		)
+
+		await app.modules
+
+		const html = await app.handle(req('/openapi')).then((x) => x.text())
+
+		const configurationMatch = html.match(/data-configuration='([^']+)'/)
+		expect(configurationMatch).not.toBeNull()
+
+		const configuration = JSON.parse(configurationMatch![1])
+		expect(configuration.content).toBeString()
+
+		const embeddedSchema = JSON.parse(configuration.content)
+		expect(embeddedSchema.openapi).toBe('3.1.2')
+	})
+
+	it('keeps null type in union schemas for OpenAPI 3.1', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2'
+			})
+		)
+
+		app.get('/nullable', () => 'hello', {
+			response: t.Union([t.String(), t.Null()])
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+
+		const response = res.paths['/nullable'].get.responses['200']
+		const schema =
+			response.content?.['application/json']?.schema ??
+			response.content?.['text/plain']?.schema
+
+		expect(schema).toBeDefined()
+		expect(schema.anyOf).toBeArray()
+		expect(schema.anyOf.some((x: any) => x.type === 'null')).toBe(true)
+	})
+
+	it('use custom Swagger-UI version', async () => {
 		const app = new Elysia().use(
 			openapi({
 				provider: 'swagger-ui',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,7 +117,7 @@ describe('OpenAPI', () => {
 		expect(embeddedSchema.openapi).toBe('3.1.2')
 	})
 
-	it('keeps null type in union schemas for OpenAPI 3.1', async () => {
+	it('converts nullable union to type-array for OpenAPI 3.1', async () => {
 		const app = new Elysia().use(
 			openapi({
 				openapiVersion: '3.1.2'
@@ -138,8 +138,58 @@ describe('OpenAPI', () => {
 			response.content?.['text/plain']?.schema
 
 		expect(schema).toBeDefined()
-		expect(schema.anyOf).toBeArray()
-		expect(schema.anyOf.some((x: any) => x.type === 'null')).toBe(true)
+		expect(schema.type).toEqual(['string', 'null'])
+		expect(schema.anyOf).toBeUndefined()
+	})
+
+	it('converts nullable union response to nullable:true for OpenAPI 3.0', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.3'
+			})
+		)
+
+		app.get('/nullable-30', () => 'hello', {
+			response: t.Union([t.String(), t.Null()])
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		const response = res.paths['/nullable-30'].get.responses['200']
+		const schema =
+			response.content?.['application/json']?.schema ??
+			response.content?.['text/plain']?.schema
+
+		expect(schema).toBeDefined()
+		expect(schema.type).toBe('string')
+		expect(schema.nullable).toBe(true)
+		expect(schema.anyOf).toBeUndefined()
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('treats null response as nullable schema for OpenAPI 3.0', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.3'
+			})
+		)
+
+		app.get('/null-30', () => null, {
+			response: t.Null()
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		const schema =
+			res.paths['/null-30'].get.responses['200'].content[
+				'application/json'
+			].schema
+
+		expect(schema.nullable).toBe(true)
+		expect(schema.type).toBeUndefined()
+		await SwaggerParser.validate(res).catch((err) => fail(err))
 	})
 
 	it('use custom Swagger-UI version', async () => {

--- a/test/openapi/null-to-openapi.test.ts
+++ b/test/openapi/null-to-openapi.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test'
+import { t } from 'elysia'
+
+import { nullToOpenApi } from '../../src/openapi'
+
+describe('OpenAPI > nullToOpenAPI', () => {
+	it('converts nullable union to nullable:true for OAS 3.0', () => {
+		const schema = t.Object({
+			promo_code: t.Optional(
+				t.Union([t.String({ example: 'SUMMER20' }), t.Null()])
+			)
+		})
+
+		const result = nullToOpenApi(schema as any, '3.0.3') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: 'string',
+			example: 'SUMMER20',
+			nullable: true
+		})
+	})
+
+	it('converts nullable union to type:[string, null] for OAS 3.1', () => {
+		const schema = t.Object({
+			promo_code: t.Optional(
+				t.Union([t.String({ example: 'SUMMER20' }), t.Null()])
+			)
+		})
+
+		const result = nullToOpenApi(schema as any, '3.1.2') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: ['string', 'null'],
+			example: 'SUMMER20'
+		})
+		expect(result.properties.promo_code.nullable).toBeUndefined()
+	})
+})

--- a/test/openapi/null-to-openapi.test.ts
+++ b/test/openapi/null-to-openapi.test.ts
@@ -35,4 +35,55 @@ describe('OpenAPI > nullToOpenAPI', () => {
 		})
 		expect(result.properties.promo_code.nullable).toBeUndefined()
 	})
+
+	it('does not treat metadata objects like default as schemas in OAS 3.0', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				promo_code: {
+					anyOf: [{ type: 'string' }, { type: 'null' }]
+				}
+			},
+			default: {
+				type: 'null',
+				reason: 'metadata'
+			}
+		}
+
+		const result = nullToOpenApi(schema as any, '3.0.3') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: 'string',
+			nullable: true
+		})
+		expect(result.default).toEqual({
+			type: 'null',
+			reason: 'metadata'
+		})
+	})
+
+	it('does not treat metadata objects like default as schemas in OAS 3.1', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				promo_code: {
+					anyOf: [{ type: 'string' }, { type: 'null' }]
+				}
+			},
+			default: {
+				type: 'null',
+				reason: 'metadata'
+			}
+		}
+
+		const result = nullToOpenApi(schema as any, '3.1.2') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: ['string', 'null']
+		})
+		expect(result.default).toEqual({
+			type: 'null',
+			reason: 'metadata'
+		})
+	})
 })


### PR DESCRIPTION
Hello friends. I've been tasked with updated Speakeasy's [Elysia integration guide](https://www.speakeasy.com/openapi/frameworks/elysia), and noticed you've got a new OpenAPI plugin to replace the Swagger plugin. **Thank you!**

You've made the first step, but there's a few issues in this otherwise fantastic approach you're taking to making OpenAPI a first-class part of the web framework. 

1. There's no version selection. People need to pick v3.0, v3.1, v3.2, as different tools have different levels of support. Many are up to v3.2 now, but some are still lagging, so people need to be able to set the version back a bit.
2. Your current OAS 3.0 support is invalid, it's putting `type: null` into the YAML and that's one of the major differences between [OpenAPI Schema and JSON Schema](https://apisyouwonthate.com/blog/openapi-json-schema-divergence/). 

Now that OpenAPI v3.1 is fully JSON Schema compatible, I've been helping tools migrate from OpenAPI v3.0 to v3.1 for years. I wrote this guide to help see what other differences: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

I don't think you do anything much with exclusiveMinimum and example vs examples is fine as its just deprecated not removed. That means you could honestly claim OpenAPI v3.1 support with this switch, and adding `nullable: true` to OAS 3.0 is fixing a bug.

This is a double win I recon.

Let me know as soon as OpenAPI v3.1 is supported so I can pop it up on [OpenAPI.Tools](https://openapi.tools/). We don't add new "legacy" tools (those that dont support at least 3.1), but the Elysia OpenAPI support is so good I'm eager to raise awareness of your framework to the OpenAPI community. 

Relates to #343, #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable OpenAPI version specification—now supports OpenAPI 3.0.x and 3.1.x versions with a default of 3.1.2
  * Updated schema normalization to handle version-specific requirements for null handling and JSON Schema dialects

* **Documentation**
  * Updated README with the new `openapiVersion` configuration option and supported version ranges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->