### PR TITLE
fix: replace invalid {"type":"Date"} with {"type":"string","format":"date-time"} in generated spec

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -684,6 +684,7 @@ export const enumToOpenApi = <
 		// Compare by canonical (sorted-key) JSON to catch different key orderings.
 		const seen = new Set<string>()
 		const deduped = mapped.filter((item) => {
+			if (!item || typeof item !== 'object') return true
 			const key = JSON.stringify(
 				Object.fromEntries(
 					Object.entries(item as object).sort(([a], [b]) =>

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -669,13 +669,13 @@ export const enumToOpenApi = <
 	// "Date" is not a valid OpenAPI 3.0 type; replace it with
 	// {"type":"string","format":"date-time"} which is what Elysia actually
 	// serialises Date instances to on the wire.  Use replace (not filter) so
-	// that nullable dates — t.Nullable(t.Date()) — keep their {"type":"null"}
+	// that nullable dates ï¿½ t.Nullable(t.Date()) ï¿½ keep their {"type":"null"}
 	// sibling instead of collapsing to null-only.
 	if (schema.anyOf && Array.isArray(schema.anyOf)) {
 		const mapped = schema.anyOf.map((item) =>
 			item &&
 			typeof item === 'object' &&
-			(item as OpenAPIV3.SchemaObject).type === 'Date'
+			(item as Record<string, unknown>).type === 'Date'
 				? { type: 'string', format: 'date-time' }
 				: enumToOpenApi(item)
 		)

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -665,6 +665,40 @@ export const enumToOpenApi = <
 			items: enumToOpenApi(schema.items)
 		} as T
 
+	// TypeBox's t.Date() serialises to anyOf: [{"type":"Date"}, ...].
+	// "Date" is not a valid OpenAPI 3.0 type; replace it with
+	// {"type":"string","format":"date-time"} which is what Elysia actually
+	// serialises Date instances to on the wire.  Use replace (not filter) so
+	// that nullable dates — t.Nullable(t.Date()) — keep their {"type":"null"}
+	// sibling instead of collapsing to null-only.
+	if (schema.anyOf && Array.isArray(schema.anyOf)) {
+		const mapped = schema.anyOf.map((item) =>
+			item &&
+			typeof item === 'object' &&
+			(item as OpenAPIV3.SchemaObject).type === 'Date'
+				? { type: 'string', format: 'date-time' }
+				: enumToOpenApi(item)
+		)
+		// Deduplicate: after the replacement above the anyOf may contain two
+		// identical date-time entries because t.Date() already included one.
+		// Compare by canonical (sorted-key) JSON to catch different key orderings.
+		const seen = new Set<string>()
+		const deduped = mapped.filter((item) => {
+			const key = JSON.stringify(
+				Object.fromEntries(
+					Object.entries(item as object).sort(([a], [b]) =>
+						a < b ? -1 : a > b ? 1 : 0
+					)
+				)
+			)
+			if (seen.has(key)) return false
+			seen.add(key)
+			return true
+		})
+		if (deduped.length === 1) return deduped[0] as T
+		return { ...schema, anyOf: deduped } as T
+	}
+
 	return schema as T
 }
 

--- a/test/openapi/enum-to-openapi.test.ts
+++ b/test/openapi/enum-to-openapi.test.ts
@@ -69,12 +69,13 @@ describe('OpenAPI > enumToOpenAPI', () => {
 		const result = enumToOpenApi(schema as any) as any
 
 		// The invalid Date entry is replaced; the duplicate date-time is removed
-		expect(result.anyOf).not.toContain(expect.objectContaining({ type: 'Date' }))
+		expect(result.anyOf).not.toContainEqual({ type: 'Date' })
+		expect(result.anyOf.filter((x: any) => x.type === 'string' && x.format === 'date-time')).toHaveLength(1)
 		expect(result.anyOf).toContainEqual({ type: 'string', format: 'date-time' })
 	})
 
 	it('should preserve {"type":"null"} sibling when replacing Date in a nullable date field', () => {
-		// t.Nullable(t.Date()) � after plugin processing � can appear as this flat anyOf
+		// t.Nullable(t.Date()) -- after plugin processing -- can appear as this flat anyOf
 		const schema = {
 			anyOf: [{ type: 'Date' }, { type: 'null' }]
 		}

--- a/test/openapi/enum-to-openapi.test.ts
+++ b/test/openapi/enum-to-openapi.test.ts
@@ -74,7 +74,7 @@ describe('OpenAPI > enumToOpenAPI', () => {
 	})
 
 	it('should preserve {"type":"null"} sibling when replacing Date in a nullable date field', () => {
-		// t.Nullable(t.Date()) — after plugin processing — can appear as this flat anyOf
+		// t.Nullable(t.Date()) ï¿½ after plugin processing ï¿½ can appear as this flat anyOf
 		const schema = {
 			anyOf: [{ type: 'Date' }, { type: 'null' }]
 		}
@@ -109,5 +109,22 @@ describe('OpenAPI > enumToOpenAPI', () => {
 			type: 'string',
 			format: 'date-time'
 		})
+	})
+
+	it('should fix Date types nested in array items', () => {
+		const schema = {
+			type: 'array',
+			items: {
+				anyOf: [
+					{ type: 'Date' },
+					{ format: 'date-time', type: 'string' }
+				]
+			}
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		// Both entries normalise to date-time; dedup collapses anyOf to a bare schema
+		expect(result.items).toEqual({ type: 'string', format: 'date-time' })
 	})
 })

--- a/test/openapi/enum-to-openapi.test.ts
+++ b/test/openapi/enum-to-openapi.test.ts
@@ -54,4 +54,60 @@ describe('OpenAPI > enumToOpenAPI', () => {
 
 		expect(result).toEqual(expectedSchema)
 	})
+
+	it('should replace {"type":"Date"} with {"type":"string","format":"date-time"} and deduplicate', () => {
+		// TypeBox t.Date() expands to this anyOf; "Date" is not a valid OpenAPI type
+		const schema = {
+			anyOf: [
+				{ type: 'Date' },
+				{ format: 'date-time', type: 'string' },
+				{ format: 'date', type: 'string' },
+				{ type: 'number' }
+			]
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		// The invalid Date entry is replaced; the duplicate date-time is removed
+		expect(result.anyOf).not.toContain(expect.objectContaining({ type: 'Date' }))
+		expect(result.anyOf).toContainEqual({ type: 'string', format: 'date-time' })
+	})
+
+	it('should preserve {"type":"null"} sibling when replacing Date in a nullable date field', () => {
+		// t.Nullable(t.Date()) — after plugin processing — can appear as this flat anyOf
+		const schema = {
+			anyOf: [{ type: 'Date' }, { type: 'null' }]
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		expect(result.anyOf).toContainEqual({ type: 'string', format: 'date-time' })
+		expect(result.anyOf).toContainEqual({ type: 'null' })
+		expect(result.anyOf).not.toContainEqual({ type: 'Date' })
+	})
+
+	it('should fix Date types nested in object properties', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				createdAt: {
+					anyOf: [
+						{ type: 'Date' },
+						{ format: 'date-time', type: 'string' },
+						{ format: 'date', type: 'string' },
+						{ type: 'number' }
+					]
+				}
+			}
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		expect(result.properties.createdAt.anyOf).not.toContainEqual({ type: 'Date' })
+		expect(result.properties.createdAt.anyOf).toContainEqual({
+			type: 'string',
+			format: 'date-time'
+		})
+	})
 })


### PR DESCRIPTION
## Problem

TypeBox's `t.Date()` serialises to:

```json
{ "anyOf": [{"type":"Date"}, {"format":"date-time","type":"string"}, {"format":"date","type":"string"}, {"type":"number"}] }
```

`"Date"` is **not a valid OpenAPI 3.0 data type** ([see spec](https://swagger.io/docs/specification/v3_0/data-models/data-types/)). Scalar, Swagger UI, and spec validators choke on this and fail to render the entire document — not just the offending field.

Closes #233. Related: #124.

## Root cause

`enumToOpenApi` in `src/openapi.ts` already recurses into `object.properties` and `array.items` but does not handle `anyOf` arrays, so the invalid `{"type":"Date"}` passes through untouched.

## Fix

Add an `anyOf` branch to `enumToOpenApi` that:

1. **Replaces** (not filters) `{"type":"Date"}` → `{"type":"string","format":"date-time"}`. Using replace instead of filter is important: filtering `{"type":"Date"}` from `t.Nullable(t.Date())` would leave only `[{"type":"null"}]`, losing the date-time information entirely. The correct output is `anyOf: [{"type":"string","format":"date-time"}, {"type":"null"}]`.

2. **Deduplicates** by canonical (sorted-key) JSON comparison, since `t.Date()`'s `anyOf` already includes `{"format":"date-time","type":"string"}` — after the replacement we'd have two equivalent entries with keys in different order.

3. **Recurses** into each `anyOf` item, so nested schemas (e.g. date fields inside objects) are also fixed.

## Tests

Three new cases in `test/openapi/enum-to-openapi.test.ts`:
- `t.Date()` standalone — `{"type":"Date"}` is replaced and deduplicated
- `t.Nullable(t.Date())` flat anyOf — `{"type":"null"}` sibling is preserved
- Date field nested inside an object property

## Prior art

PR #182 attempted this fix and was approved by @marclave but was never merged. That implementation used `.filter()`, which has the nullable-date bug described above (noted in a [January 2026 comment](https://github.com/elysiajs/elysia-openapi/pull/182#issuecomment-3809202135)). This PR uses `.map()` + deduplication to avoid that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI generation by converting TypeBox `Date` schemas found within `anyOf` to OpenAPI-compatible `string` schemas with `date-time` format.
  * Deduplicates repeated `date-time` variants to avoid redundant schema entries.
  * Preserves `null` for nullable dates, including when conversion occurs within nested object properties and array items.

* **Tests**
  * Added unit tests covering `Date` normalization in `anyOf`, deduplication behavior, nullability preservation, and nested scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->