### PR TITLE
Support OpenAPI 3.1 and stabilize schema generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup bun
-              uses: oven-sh/setup-bun@v1
+              uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
 
             - name: Install packages
               run: bun install
-              
+
             - name: Build code
               run: bun run build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Setup Bun'
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          no-cache: true
           registry-url: "https://registry.npmjs.org"
 
       - uses: actions/setup-node@v5

--- a/README.md
+++ b/README.md
@@ -60,11 +60,18 @@ Then go to `http://localhost:3000/openapi`.
 @default true
 Enable/Disable the plugin
 
+## openapiVersion
+
+@default '3.1.2'
+
+OpenAPI document version to emit. Supports OpenAPI `3.0.x` and `3.1.x`.
+
 ## documentation
 
 OpenAPI documentation information
 
-@see https://spec.openapis.org/oas/v3.0.3.html
+@see https://spec.openapis.org/oas/latest.html
+
 
 ## exclude
 

--- a/build.ts
+++ b/build.ts
@@ -8,7 +8,8 @@ const tsupConfig: Options = {
 	splitting: false,
 	sourcemap: false,
 	clean: true,
-	bundle: true
+	bundle: true,
+	external: ['typescript']
 } satisfies Options
 
 await Promise.all([

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@scalar/types": "^0.2.16",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
+        "arktype": "^2.2.1",
         "effect": "^3.21.2",
         "elysia": "1.4.19",
         "eslint": "9.6.0",
@@ -19,7 +20,11 @@
       },
       "peerDependencies": {
         "elysia": ">= 1.4.0",
+        "typescript": ">= 5.0.0",
       },
+      "optionalPeers": [
+        "typescript",
+      ],
     },
   },
   "packages": {
@@ -30,6 +35,10 @@
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
 
     "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@12.1.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "14.0.1", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng=="],
+
+    "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
+
+    "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
@@ -198,6 +207,10 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "arkregex": ["arkregex@0.0.6", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-9mvuMKQuibfWhBrsNYhsKhNb6k9oEHoAJ/FvDiqe8h+E9Siwe0/cro1WVOGgpajXQ9ZHd24yCOf2k35Q/QqUQw=="],
+
+    "arktype": ["arktype@2.2.1", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.6" } }, "sha512-CWPJxNoSxrS+NYGB3ufwc/blFonESEW5vBQyYPVS0rf4STu8VWoAWfKJSl5vVVm56h4yxpwbODeYwy6XFKvojA=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "@scalar/types": "^0.2.16",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
+        "arktype": "^2.2.1",
         "effect": "^3.21.2",
         "elysia": "1.4.19",
         "eslint": "9.6.0",
@@ -87,6 +88,12 @@
         "zod": "^4.3.6"
     },
     "peerDependencies": {
-        "elysia": ">= 1.4.0"
+        "elysia": ">= 1.4.0",
+        "typescript": ">= 5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "typescript": {
+            "optional": true
+        }
     }
 }

--- a/src/gen/index.ts
+++ b/src/gen/index.ts
@@ -2,7 +2,7 @@ import { TypeBox } from '@sinclair/typemap'
 import type { AdditionalReference } from '../types'
 
 const matchRoute = /: Elysia<(.*)>/gs
-const numberKey = /(\d+):/g
+const propertyKey = /([A-Za-z_]\w*|\d+):/g
 
 export interface OpenAPIGeneratorOptions {
 	/**
@@ -115,14 +115,321 @@ export function extractRootObjects(code: string) {
 	return results
 }
 
-export function declarationToJSONSchema(declaration: string) {
+export function extractTypeAliases(declaration: string): Record<string, string> {
+	const aliases: Record<string, string> = {}
+	const typePattern = /\btype\s+(\w+)\s*=\s*/g
+	let match: RegExpExecArray | null
+
+	while ((match = typePattern.exec(declaration)) !== null) {
+		const name = match[1]
+		const startIdx = match.index + match[0].length
+
+		if (declaration[startIdx] !== '{') continue
+
+		let depth = 0
+		let end = startIdx
+		for (; end < declaration.length; end++) {
+			if (declaration[end] === '{') depth++
+			else if (declaration[end] === '}') {
+				depth--
+				if (depth === 0) {
+					end++
+					break
+				}
+			}
+		}
+
+		aliases[name] = declaration
+			.slice(startIdx, end)
+			.replace(/\/\/[^\n]*/g, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+	}
+
+	return aliases
+}
+
+export function inlineTypeReferences(
+	code: string,
+	aliases: Record<string, string>
+): string {
+	const names = Object.keys(aliases).sort((a, b) => b.length - a.length)
+
+	for (const name of names)
+		code = code.replace(new RegExp(`\\b${name}\\b`, 'g'), aliases[name])
+
+	return code
+}
+
+const loadTypeScript = (projectRoot: string): typeof import('typescript') => {
+	const module = process.getBuiltinModule?.('module') as
+		| typeof import('module')
+		| undefined
+	const runtimeRequire =
+		typeof require === 'function'
+			? require
+			: module?.createRequire?.(join(projectRoot, 'package.json'))
+
+	if (!runtimeRequire)
+		throw new Error(
+			'[@elysiajs/openapi/gen] `fromTypes` import type resolution requires CommonJS require or module.createRequire'
+		)
+
+	try {
+		return runtimeRequire('typescript')
+	} catch {
+		throw new Error(
+			'[@elysiajs/openapi/gen] `fromTypes` import type resolution requires `typescript`. Install it with: bun add -d typescript'
+		)
+	}
+}
+
+export function resolveImportedTypes(
+	declaration: string,
+	projectRoot: string,
+	tsconfigPath: string,
+	sourceFilePath: string,
+	existingAliases: Record<string, string>,
+	fs: {
+		existsSync: (path: string) => boolean
+		readFileSync: (path: string, encoding: 'utf8') => string
+	}
+): Record<string, string> {
+	const aliases = { ...existingAliases }
+	const importPattern = /import\("([^"]+)"\)\.(\w+)/g
+	const imports = new Map<string, Set<string>>()
+	let match: RegExpExecArray | null
+
+	while ((match = importPattern.exec(declaration)) !== null) {
+		const [, modulePath, typeName] = match
+		if (aliases[typeName]) continue
+		if (!imports.has(modulePath)) imports.set(modulePath, new Set())
+		imports.get(modulePath)!.add(typeName)
+	}
+
+	if (imports.size === 0) return aliases
+
+	const ts = loadTypeScript(projectRoot)
+	const fullTsconfigPath = tsconfigPath.startsWith('/')
+		? tsconfigPath
+		: join(projectRoot, tsconfigPath)
+	let compilerOptions: Record<string, any> = {}
+
+	if (fs.existsSync(fullTsconfigPath)) {
+		const configFile = ts.readConfigFile(fullTsconfigPath, (path) =>
+			fs.readFileSync(path, 'utf8')
+		)
+
+		if (configFile.config) {
+			const parsed = ts.parseJsonConfigFileContent(
+				configFile.config,
+				ts.sys,
+				projectRoot
+			)
+			compilerOptions = parsed.options
+		}
+	}
+
+	const containingFile = sourceFilePath.startsWith('/')
+		? sourceFilePath
+		: join(projectRoot, sourceFilePath)
+
+	for (const [modulePath, typeNames] of imports) {
+		const resolved = ts.resolveModuleName(
+			modulePath,
+			containingFile,
+			compilerOptions as any,
+			ts.sys
+		)
+		const fileName = resolved.resolvedModule?.resolvedFileName
+
+		if (!fileName || !fs.existsSync(fileName)) continue
+
+		try {
+			const source = fs.readFileSync(fileName, 'utf8')
+			const moduleAliases = extractTypeAliases(source)
+
+			for (const typeName of typeNames)
+				if (moduleAliases[typeName])
+					aliases[typeName] = moduleAliases[typeName]
+		} catch {
+			// Ignore unreadable modules; unresolved imports still degrade to refs.
+		}
+	}
+
+	return aliases
+}
+
+export function flattenNestedIntersections(declaration: string): string {
+	let result = declaration
+	let changed = true
+
+	while (changed) {
+		changed = false
+		const flattened: string[] = []
+
+		for (const part of splitAtTopLevelIntersections(result)) {
+			const expanded = expandOneLevel(part)
+			if (expanded.length > 1) changed = true
+			flattened.push(...expanded)
+		}
+
+		result = flattened.join(' & ')
+	}
+
+	return result
+}
+
+const splitAtTopLevelIntersections = (declaration: string): string[] => {
+	const parts: string[] = []
+	let depth = 0
+	let start = 0
+
+	for (let i = 0; i < declaration.length; i++) {
+		const character = declaration[i]
+		if (character === '{') depth++
+		else if (character === '}') depth--
+		else if (depth === 0 && character === '&') {
+			parts.push(declaration.slice(start, i).trim())
+			start = i + 1
+		}
+	}
+
+	const last = declaration.slice(start).trim()
+	if (last) parts.push(last)
+
+	return parts.filter(Boolean)
+}
+
+const expandOneLevel = (object: string): string[] => {
+	let bestIndex = -1
+	let bestDepth = -1
+	let depth = 0
+
+	for (let i = 0; i < object.length - 4; i++) {
+		const character = object[i]
+		if (character === '{') depth++
+		else if (character === '}') {
+			depth--
+			if (/^\}\s*&\s*\{/.test(object.slice(i)) && depth > bestDepth) {
+				bestIndex = i
+				bestDepth = depth
+			}
+		}
+	}
+
+	if (bestIndex === -1) return [object]
+
+	let groupStart = -1
+	depth = 1
+	for (let i = bestIndex - 1; i >= 0; i--) {
+		if (object[i] === '}') depth++
+		else if (object[i] === '{') {
+			depth--
+			if (depth === 0) {
+				groupStart = i
+				break
+			}
+		}
+	}
+
+	if (groupStart === -1) return [object]
+
+	const members: string[] = []
+	let position = groupStart
+
+	while (position < object.length) {
+		if (object[position] !== '{') break
+
+		depth = 0
+		let end = position
+		for (; end < object.length; end++) {
+			if (object[end] === '{') depth++
+			else if (object[end] === '}') {
+				depth--
+				if (depth === 0) {
+					end++
+					break
+				}
+			}
+		}
+
+		members.push(object.slice(position, end))
+		position = end
+
+		const separator = object.slice(position).match(/^\s*&\s*/)
+		if (!separator) break
+		position += separator[0].length
+	}
+
+	if (members.length <= 1) return [object]
+
+	const prefix = object.slice(0, groupStart)
+	const suffix = object.slice(position)
+
+	return members.map((member) => prefix + member + suffix)
+}
+
+export function extractGenericParam(
+	instance: string,
+	paramIndex: number
+): string | undefined {
+	const openAngle = instance.indexOf('<')
+	if (openAngle === -1) return
+
+	let depth = 0
+	let currentParam = 0
+	let paramStart = openAngle + 1
+
+	for (let i = openAngle + 1; i < instance.length; i++) {
+		const character = instance[i]
+
+		if (
+			character === '<' ||
+			character === '{' ||
+			character === '[' ||
+			character === '('
+		)
+			depth++
+		else if (
+			character === '>' ||
+			character === '}' ||
+			character === ']' ||
+			character === ')'
+		) {
+			if (depth === 0)
+				return currentParam === paramIndex
+					? instance.slice(paramStart, i).trim()
+					: undefined
+
+			depth--
+		} else if (character === ',' && depth === 0) {
+			if (currentParam === paramIndex)
+				return instance.slice(paramStart, i).trim()
+
+			currentParam++
+			paramStart = i + 1
+		}
+	}
+}
+
+export function declarationToJSONSchema(
+	declaration: string,
+	typeAliases?: Record<string, string>
+) {
 	const routes: AdditionalReference = {}
+	const flattened = flattenNestedIntersections(declaration)
 
 	// Treaty is a collection of { ... } & { ... } & { ... }
 	for (const route of extractRootObjects(
-		declaration.replace(numberKey, '"$1":')
+		flattened.replace(propertyKey, '"$1":')
 	)) {
-		let schema = TypeBox(route.replaceAll(/readonly/g, ''))
+		let processed = route
+			.replaceAll(/readonly/g, '')
+			.replace(/import\([^)]*\)\.(\w+)/g, '$1')
+
+		if (typeAliases) processed = inlineTypeReferences(processed, typeAliases)
+
+		let schema = TypeBox(processed)
 		if (schema.type !== 'object') continue
 
 		const paths = []
@@ -260,6 +567,7 @@ export const fromTypes =
 					: ''
 
 				let distDir = join(tmpRoot, 'dist')
+				let rootDir = projectRoot
 
 				// Convert Windows path to Unix for TypeScript CLI
 				if (
@@ -269,27 +577,28 @@ export const fromTypes =
 					extendsRef = extendsRef.replace(/\\/g, '/')
 					src = src.replace(/\\/g, '/')
 					distDir = distDir.replace(/\\/g, '/')
+					rootDir = rootDir.replace(/\\/g, '/')
+				}
+
+				const resolvedCompilerOptions = {
+					lib: ['ESNext'],
+					module: 'ESNext',
+					noEmit: false,
+					declaration: true,
+					emitDeclarationOnly: true,
+					moduleResolution: 'bundler',
+					skipLibCheck: true,
+					skipDefaultLibCheck: true,
+					rootDir,
+					outDir: distDir,
+					...compilerOptions
 				}
 
 				fs.writeFileSync(
 					join(tmpRoot, 'tsconfig.json'),
 					`{
 	${extendsRef}
-	"compilerOptions": ${
-		compilerOptions
-			? JSON.stringify(compilerOptions)
-			: `{
-	"lib": ["ESNext"],
-	"module": "ESNext",
-	"noEmit": false,
-	"declaration": true,
-	"emitDeclarationOnly": true,
-	"moduleResolution": "bundler",
-	"skipLibCheck": true,
-	"skipDefaultLibCheck": true,
-	"outDir": "${distDir}"
-}`
-	},
+	"compilerOptions": ${JSON.stringify(resolvedCompilerOptions)},
 	"include": ["${src}"]
 }`
 				)
@@ -383,6 +692,16 @@ export const fromTypes =
 			if (!debug && fs.existsSync(tmpRoot))
 				fs.rmSync(tmpRoot, { recursive: true, force: true })
 
+			let typeAliases = extractTypeAliases(declaration)
+			typeAliases = resolveImportedTypes(
+				declaration,
+				projectRoot,
+				tsconfigPath,
+				src,
+				typeAliases,
+				fs
+			)
+
 			let instance = declaration.match(
 				instanceName
 					? new RegExp(`${instanceName}: Elysia<(.*)`, 'gs')
@@ -391,21 +710,10 @@ export const fromTypes =
 
 			if (!instance) return
 
-			// Get 5th generic parameter
-			// Elysia<'', {}, {}, {}, Routes>
-			// ------------------------^
-			//         1   2   3   4   5
-			// We want the 4th one
-			for (let i = 0; i < 3; i++)
-				instance = instance.slice(
-					instance.indexOf(
-						'}, {',
-						// remove just `}, `, leaving `{`
-						3
-					)
-				)
+			const routeSection = extractGenericParam(instance, 4)
+			if (!routeSection) return
 
-			return declarationToJSONSchema(instance.slice(2))
+			return declarationToJSONSchema(routeSection, typeAliases)
 		} catch (error) {
 			console.warn(
 				'[@elysiajs/openapi/gen] Failed to generate OpenAPI schema'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,35 @@
-import { Elysia } from 'elysia'
+import { Elysia, type AnyElysia } from 'elysia'
 
 import { SwaggerUIRender } from './swagger'
 import { ScalarRender } from './scalar'
 
 import { toOpenAPISchema } from './openapi'
 
-import type { OpenAPIV3 } from 'openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
-import type { ElysiaOpenAPIConfig } from './types'
+import type { ElysiaOpenAPIConfig, OpenAPIVersion } from './types'
 
-function isCloudflareWorker() {
-	try {
-		// Check for the presence of caches.default, which is a global in Workers
-		if (
-			// @ts-ignore
-			typeof caches !== 'undefined' &&
-			// @ts-ignore
-			typeof caches.default !== 'undefined'
+type OpenAPIDocument = {
+	openapi: OpenAPIVersion
+	[key: string]: unknown
+}
+
+const DEFAULT_OPENAPI_VERSION: OpenAPIVersion = '3.1.2'
+const OPENAPI_VERSION_REGEX = /^3\.(0|1)\.\d+$/
+
+const normalizeOpenAPIVersion = (
+	version: string | undefined
+): OpenAPIVersion => {
+	if (!version) return DEFAULT_OPENAPI_VERSION
+
+	if (!OPENAPI_VERSION_REGEX.test(version)) {
+		console.warn(
+			`[@elysiajs/openapi] Invalid openapiVersion "${version}". Expected 3.0.x or 3.1.x. Falling back to ${DEFAULT_OPENAPI_VERSION}.`
 		)
-			return true
 
-		// @ts-ignore
-		if (typeof WebSocketPair !== 'undefined') {
-			return true
-		}
-	} catch (e) {
-		// If accessing these globals throws an error, it's likely not a Worker
-		return false
+		return DEFAULT_OPENAPI_VERSION
 	}
 
-	return false
+	return version as OpenAPIVersion
 }
 
 /**
@@ -45,6 +45,7 @@ export const openapi = <
 	path = '/openapi' as Path,
 	provider = 'scalar',
 	specPath = `${path}/json`,
+	openapiVersion = DEFAULT_OPENAPI_VERSION,
 	documentation = {},
 	exclude,
 	swagger,
@@ -62,18 +63,32 @@ export const openapi = <
 		...documentation.info
 	}
 
-	const relativePath = specPath.startsWith('/') ? specPath.slice(1) : specPath
+	const getSpecUrl = () => {
+		if (!specPath.startsWith('/')) return specPath
+
+		const defaultSpecPath = `${path}/json`
+		if (specPath === defaultSpecPath) return specPath.slice(1)
+
+		return specPath
+	}
+
+	const specUrl = getSpecUrl()
+	const effectiveOpenAPIVersion: OpenAPIVersion =
+		normalizeOpenAPIVersion(openapiVersion)
+
+	const getRouteCount = (app: AnyElysia) =>
+		(app as any).getGlobalRoutes?.().length ?? app.routes.length
 
 	let totalRoutes = 0
-	let cachedSchema: OpenAPIV3.Document | undefined
+	let cachedSchema: OpenAPIDocument | undefined
 
 	const toFullSchema = ({
 		paths,
 		components: { schemas }
-	}: ReturnType<typeof toOpenAPISchema>): OpenAPIV3.Document => {
-		return (cachedSchema = {
-			openapi: '3.0.3',
+	}: ReturnType<typeof toOpenAPISchema>): OpenAPIDocument => {
+		const schema: OpenAPIDocument = {
 			...documentation,
+			openapi: effectiveOpenAPIVersion,
 			tags: !exclude?.tags
 				? documentation.tags
 				: documentation.tags?.filter(
@@ -96,7 +111,9 @@ export const openapi = <
 					...(documentation.components?.schemas as any)
 				}
 			}
-		})
+		}
+
+		return (cachedSchema = schema)
 	}
 
 	const app = new Elysia({ name: '@elysiajs/openapi' })
@@ -108,7 +125,7 @@ export const openapi = <
 			new Response(
 				provider === 'swagger-ui'
 					? SwaggerUIRender(info, {
-							url: relativePath,
+							url: specUrl,
 							dom_id: '#swagger-ui',
 							version: 'latest',
 							autoDarkMode: true,
@@ -117,7 +134,7 @@ export const openapi = <
 					: ScalarRender(
 							info,
 							{
-								url: relativePath,
+								url: specUrl,
 								version: 'latest',
 								cdn: `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${scalar?.version ?? 'latest'}/dist/browser/standalone.min.js`,
 								...(scalar as ApiReferenceConfiguration),
@@ -125,14 +142,15 @@ export const openapi = <
 							},
 							embedSpec
 								? JSON.stringify(
-										totalRoutes === app.routes.length
+										totalRoutes === getRouteCount(app)
 											? cachedSchema
 											: toFullSchema(
 													toOpenAPISchema(
 														app,
 														exclude,
 														references,
-														mapJsonSchema
+														mapJsonSchema,
+														effectiveOpenAPIVersion
 													)
 												)
 									)
@@ -147,7 +165,7 @@ export const openapi = <
 
 		return app.get(
 			path,
-			embedSpec || isCloudflareWorker() ? page : page(),
+			page,
 			{
 				detail: {
 					hide: true
@@ -156,14 +174,22 @@ export const openapi = <
 		)
 	}).get(
 		specPath,
-		function openAPISchema(): OpenAPIV3.Document {
-			if (totalRoutes === app.routes.length && cachedSchema)
+		function openAPISchema(): OpenAPIDocument {
+			const routeCount = getRouteCount(app)
+
+			if (totalRoutes === routeCount && cachedSchema)
 				return cachedSchema
 
-			totalRoutes = app.routes.length
+			totalRoutes = routeCount
 
 			return toFullSchema(
-				toOpenAPISchema(app, exclude, references, mapJsonSchema)
+				toOpenAPISchema(
+					app,
+					exclude,
+					references,
+					mapJsonSchema,
+					effectiveOpenAPIVersion
+				)
 			)
 		},
 		{
@@ -182,6 +208,6 @@ export const openapi = <
 
 export { fromTypes } from './gen'
 export { toOpenAPISchema, withHeaders } from './openapi'
-export type { ElysiaOpenAPIConfig }
+export type { ElysiaOpenAPIConfig, OpenAPIVersion } from './types'
 
 export default openapi

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -19,17 +19,15 @@ import type {
 	AdditionalReference,
 	AdditionalReferences,
 	ElysiaOpenAPIConfig,
-	MapJsonSchema
+	MapJsonSchema,
+	OpenAPIVersion
 } from './types'
 
 export const capitalize = (word: string) =>
 	word.charAt(0).toUpperCase() + word.slice(1)
 
-const toRef = (name: string) => t.Ref(
-	name.startsWith('#/')
-		? name
-		: `#/components/schemas/${name}`
-)
+const toRef = (name: string) =>
+	t.Ref(name.startsWith('#/') ? name : `#/components/schemas/${name}`)
 
 const toOperationId = (method: string, paths: string) => {
 	let operationId = method.toLowerCase()
@@ -249,7 +247,8 @@ const normalizeSchemaReference = (
 const mergeSchemaProperty = (
 	existing: TSchema | string | undefined,
 	incoming: TSchema | string | undefined,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ): TSchema | string | undefined => {
 	if (!existing) return incoming
 	if (!incoming) return existing
@@ -262,10 +261,20 @@ const mergeSchemaProperty = (
 	if (!incomingSchema) return existing
 
 	if (!isTSchema(incomingSchema) && incomingSchema['~standard'])
-		incomingSchema = unwrapSchema(incomingSchema, vendors) as any
+		incomingSchema = unwrapSchema(
+			incomingSchema,
+			vendors,
+			'input',
+			openapiVersion
+		) as any
 
 	if (!isTSchema(existingSchema) && existingSchema['~standard'])
-		existingSchema = unwrapSchema(existingSchema, vendors) as any
+		existingSchema = unwrapSchema(
+			existingSchema,
+			vendors,
+			'input',
+			openapiVersion
+		) as any
 
 	if (!incomingSchema) return existingSchema
 	if (!existingSchema) return incomingSchema
@@ -295,7 +304,8 @@ type ResponseSchema =
 
 const unwrapResponseSchema = (
 	schema: ResponseSchema,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ) =>
 	typeof schema === 'string'
 		? normalizeSchemaReference(schema)
@@ -305,7 +315,12 @@ const unwrapResponseSchema = (
 				? schema
 				: // @ts-ignore
 					schema['~standard']
-					? unwrapSchema(schema as any, vendors, 'output')
+					? unwrapSchema(
+							schema as any,
+							vendors,
+							'output',
+							openapiVersion
+						)
 					: Object.fromEntries(
 							Object.entries(schema).map(([status, schema]) => [
 								status,
@@ -316,7 +331,8 @@ const unwrapResponseSchema = (
 										: unwrapSchema(
 												schema as any,
 												vendors,
-												'output'
+												'output',
+												openapiVersion
 											)
 							])
 						)
@@ -327,14 +343,15 @@ const unwrapResponseSchema = (
 const mergeResponseSchema = (
 	_existing: ResponseSchema,
 	_incoming: ResponseSchema,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ): TSchema | { [status: number]: TSchema | string } | string | undefined => {
 	if (!_existing) return _incoming
 	if (!_incoming) return _existing
 
 	// Normalize string references to TRef nodes
-	let existing = unwrapResponseSchema(_existing, vendors)
-	let incoming = unwrapResponseSchema(_incoming, vendors)
+	let existing = unwrapResponseSchema(_existing, vendors, openapiVersion)
+	let incoming = unwrapResponseSchema(_incoming, vendors, openapiVersion)
 
 	if (!existing && !incoming) return undefined
 	if (incoming && !existing) return incoming as any
@@ -364,7 +381,8 @@ const mergeResponseSchema = (
 			schema[status] = mergeSchemaProperty(
 				existingSchema as TSchema,
 				incomingSchema as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 		else if (existingSchema) schema[status] = existingSchema
 		else if (incomingSchema) schema[status] = incomingSchema
@@ -390,7 +408,8 @@ const mergeStandaloneValidators = (
 	> & {
 		standaloneValidator?: InputSchema[]
 	} & InputSchema,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ) => {
 	const merged = { ...hooks }
 
@@ -402,42 +421,48 @@ const mergeStandaloneValidators = (
 			merged.body = mergeSchemaProperty(
 				merged.body as TSchema,
 				validator.body as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 
 		if (validator.headers)
 			merged.headers = mergeSchemaProperty(
 				merged.headers as TSchema,
 				validator.headers as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 
 		if (validator.query)
 			merged.query = mergeSchemaProperty(
 				merged.query as TSchema,
 				validator.query as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 
 		if (validator.params)
 			merged.params = mergeSchemaProperty(
 				merged.params as TSchema,
 				validator.params as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 
 		if (validator.cookie)
 			merged.cookie = mergeSchemaProperty(
 				merged.cookie as TSchema,
 				validator.cookie as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 
 		if (validator.response)
 			merged.response = mergeResponseSchema(
 				merged.response as TSchema,
 				validator.response as TSchema,
-				vendors
+				vendors,
+				openapiVersion
 			)
 	}
 
@@ -476,13 +501,21 @@ const mergeStandaloneValidators = (
  * This makes guard() schemas accessible in the OpenAPI spec by converting
  * the standaloneValidator array into direct hook properties.
  */
-const flattenRoutes = (routes: any[], vendors?: MapJsonSchema): any[] =>
+const flattenRoutes = (
+	routes: any[],
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
+): any[] =>
 	routes.map((route) => {
 		if (!route.hooks?.standaloneValidator?.length) return route
 
 		return {
 			...route,
-			hooks: mergeStandaloneValidators(route.hooks, vendors)
+			hooks: mergeStandaloneValidators(
+				route.hooks,
+				vendors,
+				openapiVersion
+			)
 		}
 	})
 
@@ -510,12 +543,17 @@ const unwrapReference = <T extends OpenAPIV3.SchemaObject | undefined>(
 export const unwrapSchema = (
 	schema: InputSchema['body'],
 	mapJsonSchema?: MapJsonSchema,
-	io: 'input' | 'output' = 'input'
+	io: 'input' | 'output' = 'input',
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ): OpenAPIV3.SchemaObject | undefined => {
 	if (!schema) return
 
 	if (typeof schema === 'string') schema = toRef(schema)
-	if (Kind in schema) return enumToOpenApi(schema)
+	if (Kind in schema)
+		return normalizeSchemaForOpenAPIVersion(
+			enumToOpenApi(schema),
+			openapiVersion
+		)
 
 	// Already unwrapped by merging standalone validators
 	if (
@@ -523,7 +561,10 @@ export const unwrapSchema = (
 		// @ts-ignore
 		(schema.$schema || schema.type || schema.properties || schema.items)
 	)
-		return schema as OpenAPIV3.SchemaObject
+		return normalizeSchemaForOpenAPIVersion(
+			schema as OpenAPIV3.SchemaObject,
+			openapiVersion
+		)
 
 	if (!schema?.['~standard']) return
 
@@ -531,18 +572,58 @@ export const unwrapSchema = (
 	const vendor = schema['~standard'].vendor
 
 	try {
+		const jsonSchemaTarget = openapiVersion.startsWith('3.0.')
+			? 'draft-07'
+			: 'draft-2020-12'
+
 		if (
 			mapJsonSchema?.[vendor] &&
 			typeof mapJsonSchema[vendor] === 'function'
 		)
-			return enumToOpenApi(mapJsonSchema[vendor](schema))
+			return normalizeSchemaForOpenAPIVersion(
+				enumToOpenApi(mapJsonSchema[vendor](schema)),
+				openapiVersion
+			)
+
+		// ============================================================================
+		// ArkType toJsonSchema fallback (predicates, morphs, Date, etc.)
+		// ============================================================================
+		if (vendor === 'arktype')
+			return normalizeSchemaForOpenAPIVersion(
+				enumToOpenApi(
+					// @ts-ignore
+					schema?.toJsonSchema?.({
+						fallback: {
+							// real Date types -> string with date-time format
+							date: (
+								ctx: { base: Record<string, unknown> }
+							) => ({
+								...ctx.base,
+								type: 'string',
+								format: 'date-time'
+							}),
+							// anything else unrepresentable -> keep the base type
+							default: (
+								ctx: { base: Record<string, unknown> }
+							) => ctx.base
+						}
+					})
+				),
+				openapiVersion
+			)
 
 		// @ts-ignore
 		if (schema['~standard']?.jsonSchema?.[io])
 			// @ts-ignore
-			return enumToOpenApi(schema['~standard'].jsonSchema[io]({
-				target: 'draft-2020-12'
-			}))
+			return normalizeSchemaForOpenAPIVersion(
+				enumToOpenApi(
+					// @ts-ignore
+					schema['~standard'].jsonSchema[io]({
+						target: jsonSchemaTarget
+					})
+				),
+				openapiVersion
+			)
 
 		switch (vendor) {
 			case 'zod':
@@ -598,17 +679,254 @@ export const unwrapSchema = (
 				break
 		}
 
-		if (vendor === 'arktype')
-			// @ts-ignore
-			return enumToOpenApi(schema?.toJsonSchema?.())
-
-		return enumToOpenApi(
-			// @ts-ignore
-			schema.toJSONSchema?.() ?? schema?.toJsonSchema?.()
+		return normalizeSchemaForOpenAPIVersion(
+			enumToOpenApi(
+				// @ts-ignore
+				schema.toJSONSchema?.() ?? schema?.toJsonSchema?.()
+			),
+			openapiVersion
 		)
 	} catch (error) {
 		console.warn(error)
 	}
+}
+
+const SCHEMA_OBJECT_MAP_KEYS = new Set([
+	'properties',
+	'patternProperties',
+	'$defs',
+	'definitions',
+	'dependentSchemas'
+])
+
+const SCHEMA_ARRAY_KEYS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems'])
+
+const SCHEMA_OR_BOOL_KEYS = new Set([
+	'items',
+	'additionalProperties',
+	'unevaluatedProperties',
+	'contains',
+	'not',
+	'if',
+	'then',
+	'else',
+	'propertyNames'
+])
+
+const normalizeNullableSchemaForOAS30 = (schema: unknown): unknown => {
+	if (!schema || typeof schema !== 'object') return schema
+
+	if (Array.isArray(schema))
+		return schema.map((item) => normalizeNullableSchemaForOAS30(item))
+
+	const normalized = { ...(schema as Record<string, unknown>) }
+
+	if (normalized.type === 'null') {
+		delete normalized.type
+		normalized.nullable = true
+		return normalized
+	}
+
+	if (Array.isArray(normalized.type) && normalized.type.includes('null')) {
+		const nonNullTypes = normalized.type.filter(
+			(type) => type !== 'null'
+		) as string[]
+
+		normalized.nullable = true
+
+		if (nonNullTypes.length === 1) normalized.type = nonNullTypes[0]
+		else if (nonNullTypes.length > 1) normalized.type = nonNullTypes
+		else delete normalized.type
+
+		return normalized
+	}
+
+	if (Array.isArray(normalized.anyOf)) {
+		const entries = normalized.anyOf as Array<Record<string, unknown>>
+		const nonNullEntries = entries.filter((entry) => {
+			const isNormalizedNullEntry =
+				entry?.nullable === true &&
+				!('type' in entry) &&
+				Object.keys(entry).length === 1
+
+			return entry?.type !== 'null' && !isNormalizedNullEntry
+		})
+
+		if (nonNullEntries.length !== entries.length) {
+			normalized.nullable = true
+
+			if (nonNullEntries.length === 1) {
+				delete normalized.anyOf
+				Object.assign(normalized, nonNullEntries[0])
+			} else normalized.anyOf = nonNullEntries
+		}
+	}
+
+	if (Array.isArray(normalized.oneOf)) {
+		const entries = normalized.oneOf as Array<Record<string, unknown>>
+		const nonNullEntries = entries.filter((entry) => {
+			const isNormalizedNullEntry =
+				entry?.nullable === true &&
+				!('type' in entry) &&
+				Object.keys(entry).length === 1
+
+			return entry?.type !== 'null' && !isNormalizedNullEntry
+		})
+
+		if (nonNullEntries.length !== entries.length) {
+			normalized.nullable = true
+
+			if (nonNullEntries.length === 1) {
+				delete normalized.oneOf
+				Object.assign(normalized, nonNullEntries[0])
+			} else normalized.oneOf = nonNullEntries
+		}
+	}
+
+	for (const [key, value] of Object.entries(normalized)) {
+		if (SCHEMA_OBJECT_MAP_KEYS.has(key)) {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] = normalizeNullableSchemaForOAS30(nestedValue)
+				normalized[key] = next
+			}
+			continue
+		}
+
+		if (SCHEMA_ARRAY_KEYS.has(key)) {
+			if (Array.isArray(value))
+				normalized[key] = value.map((item) =>
+					normalizeNullableSchemaForOAS30(item)
+				)
+			continue
+		}
+
+		if (SCHEMA_OR_BOOL_KEYS.has(key)) {
+			if (value && typeof value === 'object') {
+				if (Array.isArray(value))
+					normalized[key] = value.map((item) =>
+						normalizeNullableSchemaForOAS30(item)
+					)
+				else normalized[key] = normalizeNullableSchemaForOAS30(value)
+			}
+			continue
+		}
+
+		if (key === 'dependencies') {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] =
+						nestedValue &&
+						typeof nestedValue === 'object' &&
+						!Array.isArray(nestedValue)
+							? normalizeNullableSchemaForOAS30(nestedValue)
+							: nestedValue
+				normalized[key] = next
+			}
+		}
+	}
+
+	return normalized
+}
+
+const normalizeNullableSchemaForOAS31 = (schema: unknown): unknown => {
+	if (!schema || typeof schema !== 'object') return schema
+
+	if (Array.isArray(schema))
+		return schema.map((item) => normalizeNullableSchemaForOAS31(item))
+
+	const normalized = { ...(schema as Record<string, unknown>) }
+
+	const rewriteNullUnion = (key: 'anyOf' | 'oneOf') => {
+		if (!Array.isArray(normalized[key])) return
+
+		const entries = normalized[key] as Array<Record<string, unknown>>
+		const nullEntries = entries.filter((entry) => entry?.type === 'null')
+		if (nullEntries.length === 0) return
+
+		const nonNullEntries = entries.filter((entry) => entry?.type !== 'null')
+		if (nonNullEntries.length !== 1) return
+
+		const [nonNull] = nonNullEntries
+		const nonNullType = nonNull?.type
+
+		if (typeof nonNullType !== 'string') return
+
+		delete normalized[key]
+		Object.assign(normalized, nonNull)
+		normalized.type = [nonNullType, 'null']
+	}
+
+	rewriteNullUnion('anyOf')
+	rewriteNullUnion('oneOf')
+
+	for (const [key, value] of Object.entries(normalized)) {
+		if (SCHEMA_OBJECT_MAP_KEYS.has(key)) {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] = normalizeNullableSchemaForOAS31(nestedValue)
+				normalized[key] = next
+			}
+			continue
+		}
+
+		if (SCHEMA_ARRAY_KEYS.has(key)) {
+			if (Array.isArray(value))
+				normalized[key] = value.map((item) =>
+					normalizeNullableSchemaForOAS31(item)
+				)
+			continue
+		}
+
+		if (SCHEMA_OR_BOOL_KEYS.has(key)) {
+			if (value && typeof value === 'object') {
+				if (Array.isArray(value))
+					normalized[key] = value.map((item) =>
+						normalizeNullableSchemaForOAS31(item)
+					)
+				else normalized[key] = normalizeNullableSchemaForOAS31(value)
+			}
+			continue
+		}
+
+		if (key === 'dependencies') {
+			if (value && typeof value === 'object' && !Array.isArray(value)) {
+				const next: Record<string, unknown> = {}
+				for (const [nestedKey, nestedValue] of Object.entries(value))
+					next[nestedKey] =
+						nestedValue &&
+						typeof nestedValue === 'object' &&
+						!Array.isArray(nestedValue)
+							? normalizeNullableSchemaForOAS31(nestedValue)
+							: nestedValue
+				normalized[key] = next
+			}
+		}
+	}
+
+	return normalized
+}
+
+export const nullToOpenApi = <T>(
+	schema: T,
+	openapiVersion: OpenAPIVersion
+): T => {
+	if (!schema) return schema
+
+	if (openapiVersion.startsWith('3.0.'))
+		return normalizeNullableSchemaForOAS30(schema) as T
+
+	return normalizeNullableSchemaForOAS31(schema) as T
+}
+
+const normalizeSchemaForOpenAPIVersion = <T>(
+	schema: T,
+	openapiVersion: OpenAPIVersion
+): T => {
+	return nullToOpenApi(schema, openapiVersion)
 }
 
 /**
@@ -644,28 +962,152 @@ export const enumToOpenApi = <
 				type: 'string',
 				enum: schema.anyOf.map((item) => item.const)
 			} as any
+
+		if (schema[Kind] === 'Ref' && schema.$ref)
+			return toRef(schema.$ref) as any
 	}
 
-	const schema = _schema as OpenAPIV3.SchemaObject
+	if (Array.isArray(_schema))
+		return _schema.map((item) => enumToOpenApi(item)) as unknown as T
 
-	if (schema.type === 'object' && schema.properties) {
-		const properties: Record<string, unknown> = {}
-		for (const [key, value] of Object.entries(schema.properties))
-			properties[key] = enumToOpenApi(value)
+	const schema = _schema as OpenAPIV3.SchemaObject & Record<string, unknown>
 
-		return {
-			...schema,
-			properties
-		} as T
+	// TypeBox's t.Date() serialises to anyOf: [{"type":"Date"}, ...].
+	// "Date" is not a valid OpenAPI 3.0 type; replace it with
+	// {"type":"string","format":"date-time"} which is what Elysia actually
+	// serialises Date instances to on the wire.  Use replace (not filter) so
+	// that nullable dates -- t.Nullable(t.Date()) -- keep their {"type":"null"}
+	// sibling instead of collapsing to null-only.
+	if (schema.anyOf && Array.isArray(schema.anyOf)) {
+		const mapped = schema.anyOf.map((item) =>
+			item &&
+			typeof item === 'object' &&
+			(item as Record<string, unknown>).type === 'Date'
+				? { type: 'string', format: 'date-time' }
+				: enumToOpenApi(item)
+		)
+		// Deduplicate: after the replacement above the anyOf may contain two
+		// identical date-time entries because t.Date() already included one.
+		// Compare by canonical (sorted-key) JSON to catch different key orderings.
+		const seen = new Set<string>()
+		const deduped = mapped.filter((item) => {
+			if (!item || typeof item !== 'object') return true
+			const key = JSON.stringify(
+				Object.fromEntries(
+					Object.entries(item as object).sort(([a], [b]) =>
+						a < b ? -1 : a > b ? 1 : 0
+					)
+				)
+			)
+			if (seen.has(key)) return false
+			seen.add(key)
+			return true
+		})
+		if (deduped.length === 1) return deduped[0] as T
+		return { ...schema, anyOf: deduped } as T
 	}
 
-	if (schema.type === 'array' && schema.items)
-		return {
-			...schema,
-			items: enumToOpenApi(schema.items)
-		} as T
+	const normalized: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(schema))
+		normalized[key] =
+			value && typeof value === 'object'
+				? enumToOpenApi(value as any)
+				: value
 
-	return schema as T
+	return normalized as T
+}
+
+const toResponseHeaders = (
+	schema: InputSchema['body'],
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
+): Record<string, OpenAPIV3.HeaderObject> | undefined => {
+	const headers =
+		schema && typeof schema === 'object' && !Array.isArray(schema)
+			? (schema as { headers?: TProperties }).headers
+			: undefined
+
+	if (!headers) return
+
+	const entries = Object.entries(headers)
+		.map(
+			([name, headerSchema]) =>
+				[
+					name,
+					{
+						schema: unwrapSchema(
+							headerSchema as any,
+							vendors,
+							'output',
+							openapiVersion
+						)
+					}
+				] as const
+		)
+		.filter(([, header]) => header.schema)
+
+	return entries.length ? Object.fromEntries(entries) : undefined
+}
+
+const stripHeaders = <
+	T extends OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+>(
+	schema: T
+): T => {
+	const { headers, ...rest } = schema as T & { headers?: unknown }
+	return rest as T
+}
+
+const VOID_RESPONSE_TYPES = new Set(['void', 'null', 'undefined'])
+const PLAIN_RESPONSE_TYPES = new Set([
+	'string',
+	'number',
+	'integer',
+	'boolean'
+])
+
+const toResponseContent = (
+	schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+	type: string | undefined,
+	description: string | undefined
+) =>
+	VOID_RESPONSE_TYPES.has(type!)
+		? ({ type, description } as any)
+		: PLAIN_RESPONSE_TYPES.has(type!)
+			? { 'text/plain': { schema } }
+			: { 'application/json': { schema } }
+
+const toResponseObject = (
+	schema: InputSchema['body'],
+	status: string,
+	definitions: Record<string, unknown>,
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
+): OpenAPIV3.ResponseObject | undefined => {
+	const response = unwrapSchema(schema, vendors, 'output', openapiVersion)
+	if (!response) return
+
+	const responseSchema = stripHeaders(response)
+	// @ts-ignore Must exclude $ref from root options
+	const { type, description } = unwrapReference(responseSchema, definitions)
+	const headers = toResponseHeaders(schema, vendors, openapiVersion)
+
+	return {
+		description: description ?? `Response for status ${status}`,
+		...(headers ? { headers } : {}),
+		content: toResponseContent(responseSchema, type, description)
+	}
+}
+
+const isLikelyStaticFilePath = (path: string) => {
+	const segment = path.split('/').pop()
+	if (!segment) return false
+
+	const dotIndex = segment.lastIndexOf('.')
+	if (dotIndex <= 0 || dotIndex === segment.length - 1) return false
+
+	const extension = segment.slice(dotIndex + 1)
+	return /^[A-Za-z][A-Za-z0-9]{0,15}$/.test(extension)
 }
 
 /**
@@ -677,7 +1119,8 @@ export function toOpenAPISchema(
 	app: AnyElysia,
 	exclude?: ElysiaOpenAPIConfig['exclude'],
 	references?: AdditionalReferences,
-	vendors?: MapJsonSchema
+	vendors?: MapJsonSchema,
+	openapiVersion: OpenAPIVersion = '3.1.2'
 ) {
 	let {
 		methods: excludeMethods = ['options'],
@@ -692,6 +1135,10 @@ export function toOpenAPISchema(
 		: typeof exclude?.paths !== 'undefined'
 			? [exclude.paths]
 			: []
+
+	const ignorePatterns: RegExp[] = excludePaths.filter(
+		(path): path is RegExp => path instanceof RegExp
+	)
 
 	const paths: OpenAPIV3.PathsObject = Object.create(null)
 	// @ts-ignore
@@ -710,21 +1157,27 @@ export function toOpenAPISchema(
 	// Flatten routes to merge guard() schemas into direct hook properties
 	// This makes guard schemas accessible for OpenAPI documentation generation
 	// @ts-ignore private property
-	const routes = flattenRoutes(app.getGlobalRoutes(), vendors)
+	const routes = flattenRoutes(
+		(app as any).getGlobalRoutes(),
+		vendors,
+		openapiVersion
+	)
 	for (const route of routes) {
 		if (route.hooks?.detail?.hide) continue
 
 		const method = route.method.toLowerCase()
+		const shouldExclude = ignorePatterns.some((pattern) => pattern.test(route.path))
 
 		if (
-			(excludeStaticFile && route.path.includes('.')) ||
+			(excludeStaticFile && isLikelyStaticFilePath(route.path)) ||
 			excludePaths.includes(route.path) ||
-			excludeMethods.includes(method)
+			excludeMethods.includes(method) ||
+			shouldExclude
 		)
 			continue
 
 		const hooks: InputSchema & {
-			detail: Partial<OpenAPIV3.OperationObject>
+			detail?: Partial<OpenAPIV3.OperationObject>
 		} = route.hooks ?? {}
 
 		if (references?.length)
@@ -784,7 +1237,7 @@ export function toOpenAPISchema(
 
 		if (
 			excludeTags &&
-			hooks.detail.tags?.some((tag) => excludeTags?.includes(tag))
+			hooks.detail?.tags?.some((tag) => excludeTags?.includes(tag))
 		)
 			continue
 
@@ -803,7 +1256,7 @@ export function toOpenAPISchema(
 		// Handle path parameters
 		if (hooks.params) {
 			const params = unwrapReference(
-				unwrapSchema(hooks.params, vendors),
+				unwrapSchema(hooks.params, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -831,7 +1284,7 @@ export function toOpenAPISchema(
 		// Handle query parameters
 		if (hooks.query) {
 			const query = unwrapReference(
-				unwrapSchema(hooks.query, vendors),
+				unwrapSchema(hooks.query, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -850,7 +1303,7 @@ export function toOpenAPISchema(
 		// Handle header parameters
 		if (hooks.headers) {
 			const headers = unwrapReference(
-				unwrapSchema(hooks.headers, vendors),
+				unwrapSchema(hooks.headers, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -869,7 +1322,7 @@ export function toOpenAPISchema(
 		// Handle cookie parameters
 		if (hooks.cookie) {
 			const cookie = unwrapReference(
-				unwrapSchema(hooks.cookie, vendors),
+				unwrapSchema(hooks.cookie, vendors, 'input', openapiVersion),
 				definitions
 			)
 
@@ -890,7 +1343,12 @@ export function toOpenAPISchema(
 
 		// Handle request body
 		if (hooks.body && method !== 'get' && method !== 'head') {
-			const body = unwrapSchema(hooks.body, vendors)
+			const body = unwrapSchema(
+				hooks.body,
+				vendors,
+				'input',
+				openapiVersion
+			)
 
 			if (body) {
 				// @ts-ignore
@@ -933,6 +1391,24 @@ export function toOpenAPISchema(
 							case 'formdata':
 							case 'multipart/form-data':
 								content['multipart/form-data'] = {
+									schema: body
+								}
+								continue
+
+							case 'none':
+								// When parse is "none", include all common content types
+								// since the raw body could be any format
+								content['application/json'] = { schema: body }
+								content['application/x-www-form-urlencoded'] = {
+									schema: body
+								}
+								content['multipart/form-data'] = { schema: body }
+								content['text/plain'] = { schema: body }
+								continue
+
+							case 'arrayBuffer':
+							case 'application/octet-stream':
+								content['application/octet-stream'] = {
 									schema: body
 								}
 								continue
@@ -980,84 +1456,33 @@ export function toOpenAPISchema(
 
 			if (
 				typeof hooks.response === 'object' &&
+				!(Kind in (hooks.response as object)) &&
 				// TypeBox
 				!(hooks.response as TSchema).type &&
 				!(hooks.response as TSchema).$ref &&
 				!(hooks.response as any)['~standard']
 			) {
 				for (let [status, schema] of Object.entries(hooks.response)) {
-					const response = unwrapSchema(schema, vendors, 'output')
+					const response = toResponseObject(
+						schema as InputSchema['body'],
+						status,
+						definitions,
+						vendors,
+						openapiVersion
+					)
 
-					if (!response) continue
-
-					// @ts-ignore Must exclude $ref from root options
-					const { type, description, $ref, ..._options } =
-						unwrapReference(response, definitions)
-
-					operation.responses[status] = {
-						description:
-							description ?? `Response for status ${status}`,
-						content:
-							type === 'void' ||
-							type === 'null' ||
-							type === 'undefined'
-								? ({ type, description } as any)
-								: type === 'string' ||
-									  type === 'number' ||
-									  type === 'integer' ||
-									  type === 'boolean'
-									? {
-											'text/plain': {
-												schema: response
-											}
-										}
-									: {
-											'application/json': {
-												schema: response
-											}
-										}
-					}
+					if (response) operation.responses[status] = response
 				}
 			} else {
-				const response = unwrapSchema(
+				const response = toResponseObject(
 					hooks.response as any,
+					'200',
+					definitions,
 					vendors,
-					'output'
+					openapiVersion
 				)
 
-				if (response) {
-					// @ts-ignore
-					const {
-						type: _type,
-						description,
-						...options
-					} = unwrapReference(response, definitions)
-					const type = _type as string | undefined
-
-					// It's a single schema, default to 200
-					operation.responses['200'] = {
-						description: description ?? `Response for status 200`,
-						content:
-							type === 'void' ||
-							type === 'null' ||
-							type === 'undefined'
-								? ({ type, description } as any)
-								: type === 'string' ||
-									  type === 'number' ||
-									  type === 'integer' ||
-									  type === 'boolean'
-									? {
-											'text/plain': {
-												schema: response
-											}
-										}
-									: {
-											'application/json': {
-												schema: response
-											}
-										}
-					}
-				}
+				if (response) operation.responses['200'] = response
 			}
 		}
 
@@ -1102,7 +1527,12 @@ export function toOpenAPISchema(
 
 	if (definitions)
 		for (const [name, schema] of Object.entries(definitions)) {
-			const jsonSchema = unwrapSchema(schema as any, vendors) as
+			const jsonSchema = unwrapSchema(
+				schema as any,
+				vendors,
+				'input',
+				openapiVersion
+			) as
 				| OpenAPIV3.SchemaObject
 				| undefined
 
@@ -1117,7 +1547,16 @@ export function toOpenAPISchema(
 	} satisfies Pick<OpenAPIV3.Document, 'paths' | 'components'>
 }
 
-export const withHeaders = (schema: TSchema, headers: TProperties) =>
-	Object.assign(schema, {
-		headers: headers
-	})
+export const withHeaders = <S extends TSchema, H extends TProperties>(
+	schema: S,
+	headers: H
+) => {
+	const clone = Object.create(
+		Object.getPrototypeOf(schema),
+		Object.getOwnPropertyDescriptors(schema)
+	) as S & { headers: H }
+
+	clone.headers = headers
+
+	return clone
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1003,7 +1003,10 @@ export const enumToOpenApi = <
 			seen.add(key)
 			return true
 		})
-		if (deduped.length === 1) return deduped[0] as T
+		if (deduped.length === 1) {
+			const { anyOf, ...rest } = schema
+			return { ...rest, ...(deduped[0] as object) } as T
+		}
 		return { ...schema, anyOf: deduped } as T
 	}
 
@@ -1070,9 +1073,9 @@ const toResponseContent = (
 	schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
 	type: string | undefined,
 	description: string | undefined
-) =>
+): OpenAPIV3.ResponseObject['content'] | undefined =>
 	VOID_RESPONSE_TYPES.has(type!)
-		? ({ type, description } as any)
+		? undefined
 		: PLAIN_RESPONSE_TYPES.has(type!)
 			? { 'text/plain': { schema } }
 			: { 'application/json': { schema } }
@@ -1091,11 +1094,12 @@ const toResponseObject = (
 	// @ts-ignore Must exclude $ref from root options
 	const { type, description } = unwrapReference(responseSchema, definitions)
 	const headers = toResponseHeaders(schema, vendors, openapiVersion)
+	const content = toResponseContent(responseSchema, type, description)
 
 	return {
 		description: description ?? `Response for status ${status}`,
 		...(headers ? { headers } : {}),
-		content: toResponseContent(responseSchema, type, description)
+		...(content ? { content } : {})
 	}
 }
 
@@ -1166,7 +1170,10 @@ export function toOpenAPISchema(
 		if (route.hooks?.detail?.hide) continue
 
 		const method = route.method.toLowerCase()
-		const shouldExclude = ignorePatterns.some((pattern) => pattern.test(route.path))
+		const shouldExclude = ignorePatterns.some((pattern) => {
+			pattern.lastIndex = 0
+			return pattern.test(route.path)
+		})
 
 		if (
 			(excludeStaticFile && isLikelyStaticFilePath(route.path)) ||

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -149,7 +149,7 @@ export const ScalarRender = (
       }
     </style>
     <style>
-      ${config.customCss ?? elysiaCSS}
+      ${config.customCss || config.theme ? config.customCss : elysiaCSS}
     </style>
   </head>
   <body>

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -149,7 +149,7 @@ export const ScalarRender = (
       }
     </style>
     <style>
-      ${config.customCss || config.theme ? config.customCss : elysiaCSS}
+      ${config.customCss ?? (config.theme ? '' : elysiaCSS)}
     </style>
   </head>
   <body>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,27 @@
 import type { TSchema } from 'elysia'
-import type { OpenAPIV3 } from 'openapi-types'
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
 
 export type OpenAPIProvider = 'scalar' | 'swagger-ui' | null
+export type OpenAPIVersion = `3.0.${number}` | `3.1.${number}`
 
 type MaybeArray<T> = T | T[]
+type OpenAPITagGroup = {
+	name: string
+	tags: string[]
+}
+
+type OpenAPIDocumentation = Omit<
+	Partial<OpenAPIV3.Document> & Partial<OpenAPIV3_1.Document>,
+	| 'x-express-openapi-additional-middleware'
+	| 'x-express-openapi-validation-strict'
+> & {
+	/**
+	 * Group tags in Scalar UI using the `x-tagGroups` extension.
+	 */
+	'x-tagGroups'?: OpenAPITagGroup[]
+}
 
 export type MapJsonSchema = { [vendor: string]: Function } & {
 	[vendor in  // schema['~standard'].vendor
@@ -44,15 +60,20 @@ export interface ElysiaOpenAPIConfig<
 	enabled?: Enabled
 
 	/**
+	 * OpenAPI document version to emit
+	 *
+	 * Supports OpenAPI 3.0.x and 3.1.x
+	 *
+	 * @default '3.1.2'
+	 */
+	openapiVersion?: OpenAPIVersion
+
+	/**
 	 * OpenAPI config
 	 *
-	 * @see https://spec.openapis.org/oas/v3.0.3.html
+	 * @see https://spec.openapis.org/oas/latest.html
 	 */
-	documentation?: Omit<
-		Partial<OpenAPIV3.Document>,
-		| 'x-express-openapi-additional-middleware'
-		| 'x-express-openapi-validation-strict'
-	>
+	documentation?: OpenAPIDocumentation
 
 	exclude?: {
 		/**

--- a/test/gen/index.test.ts
+++ b/test/gen/index.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { declarationToJSONSchema, fromTypes } from '../../src/gen'
+import {
+	declarationToJSONSchema,
+	extractGenericParam,
+	extractTypeAliases,
+	flattenNestedIntersections,
+	fromTypes,
+	inlineTypeReferences
+} from '../../src/gen'
 
 const serializable = (
 	a: Record<string, unknown> | undefined
@@ -430,7 +440,6 @@ describe('Gen > Type Gen', () => {
 
 		expect(serializable(reference)!).toEqual({
 			'/': {
-				derive: {},
 				get: {
 					body: {},
 					headers: {},
@@ -440,7 +449,9 @@ describe('Gen > Type Gen', () => {
 					},
 					query: {},
 					response: {
-						'204': {},
+						'204': {
+							type: 'void'
+						},
 						'422': {
 							properties: {
 								expected: {
@@ -468,11 +479,7 @@ describe('Gen > Type Gen', () => {
 							type: 'object'
 						}
 					}
-				},
-				resolve: {},
-				response: {},
-				schema: {},
-				standaloneschema: {}
+				}
 			},
 			'/character': {
 				post: {
@@ -647,5 +654,421 @@ describe('Gen > Type Gen', () => {
 				}
 			}
 		})
+	})
+
+	it('handle alphanumeric route keys like v1', () => {
+		const reference = declarationToJSONSchema(`
+			{
+				v1: {
+					foo: {
+						get: {
+							params: {}
+							query: {}
+							headers: {}
+							body: {}
+							response: {
+								200: {
+									value: number
+								}
+							}
+						}
+					}
+				}
+			}`)
+
+		expect(serializable(reference)!).toEqual({
+			'/v1/foo': {
+				get: {
+					body: {
+						properties: {},
+						type: 'object'
+					},
+					headers: {
+						properties: {},
+						type: 'object'
+					},
+					params: {
+						properties: {},
+						type: 'object'
+					},
+					query: {
+						properties: {},
+						type: 'object'
+					},
+					response: {
+						'200': {
+							properties: {
+								value: {
+									type: 'number'
+								}
+							},
+							required: ['value'],
+							type: 'object'
+						}
+					}
+				}
+			}
+		})
+	})
+
+	it('handle route segments ending with digits', () => {
+		const reference = declarationToJSONSchema(`
+			{
+				encode: {
+					base64: {
+						get: {
+							params: {}
+							query: {}
+							headers: {}
+							body: {}
+							response: {
+								200: string
+							}
+						}
+					}
+				}
+			} & {
+				hash: {
+					sha256: {
+						get: {
+							params: {}
+							query: {}
+							headers: {}
+							body: {}
+							response: {
+								200: string
+							}
+						}
+					}
+				}
+			}`)
+
+		expect(serializable(reference)!).toMatchObject({
+			'/encode/base64': {
+				get: {
+					response: {
+						'200': {
+							type: 'string'
+						}
+					}
+				}
+			},
+			'/hash/sha256': {
+				get: {
+					response: {
+						'200': {
+							type: 'string'
+						}
+					}
+				}
+			}
+		})
+	})
+
+	it('inline type aliases into body and response schemas', () => {
+		const reference = declarationToJSONSchema(
+			`
+			{
+				users: {
+					post: {
+						params: {}
+						query: unknown
+						headers: unknown
+						body: CreateUserInput
+						response: {
+							201: User
+							400: ErrorResponse
+						}
+					}
+				}
+			}`,
+			{
+				CreateUserInput: '{ name: string; email: string }',
+				User: '{ id: string; name: string; email: string }',
+				ErrorResponse: '{ message: string; code: number }'
+			}
+		)
+
+		const route = serializable(reference)!['/users'] as any
+
+		expect(route.post.body).toEqual({
+			properties: {
+				name: { type: 'string' },
+				email: { type: 'string' }
+			},
+			required: ['name', 'email'],
+			type: 'object'
+		})
+		expect(route.post.response['201']).toEqual({
+			properties: {
+				id: { type: 'string' },
+				name: { type: 'string' },
+				email: { type: 'string' }
+			},
+			required: ['id', 'name', 'email'],
+			type: 'object'
+		})
+		expect(route.post.response['400']).toEqual({
+			properties: {
+				message: { type: 'string' },
+				code: { type: 'number' }
+			},
+			required: ['message', 'code'],
+			type: 'object'
+		})
+	})
+
+	it('extract generic route parameter without depending on object-shaped prefixes', () => {
+		const instance = `declare const app: Elysia<
+			"/api/v1",
+			any,
+			{ decorator: { token: string } },
+			{},
+			{ users: { get: { response: { 200: User } } } },
+			{ metadata: true }
+		>`
+
+		expect(extractGenericParam(instance, 4)).toBe(
+			'{ users: { get: { response: { 200: User } } } }'
+		)
+	})
+
+	it('flatten nested route intersections', () => {
+		const flattened = flattenNestedIntersections(`
+			{
+				api: {
+					v1: ({
+						users: {
+							get: {
+								params: {}
+								query: unknown
+								headers: unknown
+								body: unknown
+								response: { 200: string }
+							}
+						}
+					} & {
+							posts: {
+								get: {
+									params: {}
+									query: unknown
+									headers: unknown
+									body: unknown
+									response: { 200: string }
+								}
+							}
+						})
+					}
+				}
+			}`)
+
+		const reference = declarationToJSONSchema(flattened)
+		expect(serializable(reference)!).toMatchObject({
+			'/api/v1/users': {
+				get: {
+					response: {
+						'200': {
+							type: 'string'
+						}
+					}
+				}
+			},
+			'/api/v1/posts': {
+				get: {
+					response: {
+						'200': {
+							type: 'string'
+						}
+					}
+				}
+			}
+		})
+	})
+
+	it('extracts and inlines type aliases from fromTypes declaration files', () => {
+		const tmpRoot = mkdtempSync(join(tmpdir(), 'elysia-openapi-'))
+		const declarationPath = join(tmpRoot, 'app.d.ts')
+
+		try {
+			writeFileSync(
+				declarationPath,
+				`
+				type User = { id: string; name: string }
+				export declare const app: Elysia<
+					"",
+					{},
+					{},
+					{},
+					{
+						users: {
+							get: {
+								params: {}
+								query: unknown
+								headers: unknown
+								body: unknown
+								response: {
+									200: User
+								}
+							}
+						}
+					},
+					{},
+					{}
+				>
+				`
+			)
+
+			const reference = fromTypes(declarationPath, {
+				projectRoot: tmpRoot,
+				silent: true
+			})()
+
+			expect(
+				(serializable(reference)!['/users'] as any).get.response['200']
+			).toEqual({
+				properties: {
+					id: { type: 'string' },
+					name: { type: 'string' }
+				},
+				required: ['id', 'name'],
+				type: 'object'
+			})
+		} finally {
+			rmSync(tmpRoot, { recursive: true, force: true })
+		}
+	})
+
+	it('resolves import type references from fromTypes declaration files', () => {
+		const tmpRoot = mkdtempSync(join(tmpdir(), 'elysia-openapi-'))
+		const declarationPath = join(tmpRoot, 'app.d.ts')
+		const modelPath = join(tmpRoot, 'models.d.ts')
+
+		try {
+			writeFileSync(
+				modelPath,
+				'export type User = { id: string; email: string }'
+			)
+			writeFileSync(
+				declarationPath,
+				`
+				export declare const app: Elysia<
+					"",
+					{},
+					{},
+					{},
+					{
+						users: {
+							get: {
+								params: {}
+								query: unknown
+								headers: unknown
+								body: unknown
+								response: {
+									200: import("./models").User
+								}
+							}
+						}
+					},
+					{},
+					{}
+				>
+				`
+			)
+
+			const reference = fromTypes(declarationPath, {
+				projectRoot: tmpRoot,
+				silent: true
+			})()
+
+			expect(
+				(serializable(reference)!['/users'] as any).get.response['200']
+			).toEqual({
+				properties: {
+					id: { type: 'string' },
+					email: { type: 'string' }
+				},
+				required: ['id', 'email'],
+				type: 'object'
+			})
+		} finally {
+			rmSync(tmpRoot, { recursive: true, force: true })
+		}
+	})
+
+	it('keeps unresolved import type references as generated schemas', () => {
+		const reference = declarationToJSONSchema(`
+			{
+				users: {
+					get: {
+						params: {}
+						query: unknown
+						headers: unknown
+						body: unknown
+						response: {
+							200: {
+								id: string
+								updates: import("some/module").Unknown[] | null
+							}
+						}
+					}
+				}
+			}`)
+
+		const response = (serializable(reference)!['/users'] as any).get
+			.response['200']
+
+		expect(response.properties.id).toEqual({
+			type: 'string'
+		})
+		expect(response.properties.updates).toBeDefined()
+	})
+
+	it('extract and inline type alias helpers avoid partial replacements', () => {
+		const aliases = extractTypeAliases(`
+			type User = { id: string }
+			type UserProfile = { userId: string }
+		`)
+
+		expect(Object.keys(aliases)).toEqual(['User', 'UserProfile'])
+		expect(
+			inlineTypeReferences('profile: UserProfile; user: User', aliases)
+		).toBe('profile: { userId: string }; user: { id: string }')
+	})
+
+	it('merge compilerOptions override with declaration defaults', () => {
+		const tmpRoot = mkdtempSync(join(tmpdir(), 'elysia-openapi-'))
+
+		try {
+			const reference = fromTypes('test/gen/sample.ts', {
+				tmpRoot,
+				debug: true,
+				silent: true,
+				compilerOptions: {
+					strict: true
+				}
+			})()
+
+			expect(serializable(reference)!).toBeDefined()
+
+			const tsconfig = JSON.parse(
+				readFileSync(join(tmpRoot, 'tsconfig.json'), 'utf8')
+			)
+
+			expect(tsconfig.compilerOptions).toMatchObject({
+				lib: ['ESNext'],
+				module: 'ESNext',
+				noEmit: false,
+				declaration: true,
+				emitDeclarationOnly: true,
+				moduleResolution: 'bundler',
+				skipLibCheck: true,
+				skipDefaultLibCheck: true,
+				rootDir: process.cwd(),
+				outDir: join(tmpRoot, 'dist'),
+				strict: true
+			})
+		} finally {
+			rmSync(tmpRoot, { recursive: true, force: true })
+		}
 	})
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -147,6 +147,7 @@ describe('OpenAPI', () => {
 
 		expect(html).toContain('"theme":"moon"')
 		expect(html).not.toContain('--scalar-color-accent')
+		expect(html).not.toContain('undefined')
 	})
 
 	it('converts nullable union to type-array for OpenAPI 3.1', async () => {
@@ -406,10 +407,7 @@ describe('OpenAPI', () => {
 		expect(response.paths['/void'].get.responses['204'].description).toBe(
 			'Void response'
 		)
-		expect(response.paths['/void'].get.responses['204'].content).toEqual({
-			description: 'Void response',
-			type: 'void'
-		})
+		expect(response.paths['/void'].get.responses['204'].content).toBeUndefined()
 	})
 
 	it('should not return content response when using Undefined type', async () => {
@@ -431,12 +429,9 @@ describe('OpenAPI', () => {
 		expect(
 			response.paths['/undefined'].get.responses['204'].description
 		).toBe('Undefined response')
-		expect(
-			response.paths['/undefined'].get.responses['204'].content
-		).toEqual({
-			type: 'undefined',
-			description: 'Undefined response'
-		})
+			expect(
+				response.paths['/undefined'].get.responses['204'].content
+			).toBeUndefined()
 	})
 
 	it('should not return content response when using Null type', async () => {
@@ -456,10 +451,7 @@ describe('OpenAPI', () => {
 		expect(response.paths['/null'].get.responses['204'].description).toBe(
 			'Null response'
 		)
-		expect(response.paths['/null'].get.responses['204'].content).toEqual({
-			type: 'null',
-			description: 'Null response'
-		})
+		expect(response.paths['/null'].get.responses['204'].content).toBeUndefined()
 	})
 
 	it('should set the required field to true when a request body is present', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,8 +7,8 @@ import { fail } from 'assert'
 
 const req = (path: string) => new Request(`http://localhost${path}`)
 
-describe('Swagger', () => {
-	it('show Swagger page', async () => {
+describe('OpenAPI', () => {
+	it('show OpenAPI page', async () => {
 		const app = new Elysia().use(openapi())
 
 		await app.modules
@@ -17,17 +17,214 @@ describe('Swagger', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('show OpenAPI page more than once', async () => {
+		const app = new Elysia().use(openapi())
+
+		await app.modules
+
+		const first = await app.handle(req('/openapi'))
+		expect(first.status).toBe(200)
+		expect(await first.text()).toContain('api-reference')
+
+		const second = await app.handle(req('/openapi'))
+		expect(second.status).toBe(200)
+		expect(await second.text()).toContain('api-reference')
+	})
+
 	it('returns a valid OpenAPI json config', async () => {
 		const app = new Elysia().use(openapi())
 
 		await app.modules
 
 		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
-		expect(res.openapi).toBe('3.0.3')
+		expect(res.openapi).toBe('3.1.2')
 		await SwaggerParser.validate(res).catch((err) => fail(err))
 	})
 
-	it('use custom Swagger version', async () => {
+	it('emits OpenAPI 3.0.x when configured', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.1'
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.0.1')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('emits OpenAPI 3.1.x when configured', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.1'
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.1')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('passes through jsonSchemaDialect for OpenAPI 3.1', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				documentation: {
+					jsonSchemaDialect:
+						'https://json-schema.org/draft/2020-12/schema'
+				}
+			})
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.2')
+		expect(res.jsonSchemaDialect).toBe(
+			'https://json-schema.org/draft/2020-12/schema'
+		)
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('supports OpenAPI 3.1 with swagger-ui provider', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				provider: 'swagger-ui'
+			})
+		)
+
+		await app.modules
+
+		const page = await app.handle(req('/openapi'))
+		expect(page.status).toBe(200)
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		expect(res.openapi).toBe('3.1.2')
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('embeds OpenAPI 3.1 spec in scalar provider when embedSpec is enabled', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2',
+				provider: 'scalar',
+				embedSpec: true
+			})
+		)
+
+		await app.modules
+
+		const html = await app.handle(req('/openapi')).then((x) => x.text())
+
+		const configurationMatch = html.match(/data-configuration='([^']+)'/)
+		expect(configurationMatch).not.toBeNull()
+
+		const configuration = JSON.parse(configurationMatch![1])
+		expect(configuration.content).toBeString()
+
+		const embeddedSchema = JSON.parse(configuration.content)
+		expect(embeddedSchema.openapi).toBe('3.1.2')
+	})
+
+	it('does not inject default Scalar CSS when a Scalar theme is configured', async () => {
+		const app = new Elysia().use(
+			openapi({
+				provider: 'scalar',
+				scalar: {
+					theme: 'moon'
+				}
+			})
+		)
+
+		await app.modules
+
+		const html = await app.handle(req('/openapi')).then((x) => x.text())
+
+		expect(html).toContain('"theme":"moon"')
+		expect(html).not.toContain('--scalar-color-accent')
+	})
+
+	it('converts nullable union to type-array for OpenAPI 3.1', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.1.2'
+			})
+		)
+
+		app.get('/nullable', () => 'hello', {
+			response: t.Union([t.String(), t.Null()])
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+
+		const response = res.paths['/nullable'].get.responses['200']
+		const schema =
+			response.content?.['application/json']?.schema ??
+			response.content?.['text/plain']?.schema
+
+		expect(schema).toBeDefined()
+		expect(schema.type).toEqual(['string', 'null'])
+		expect(schema.anyOf).toBeUndefined()
+	})
+
+	it('converts nullable union response to nullable:true for OpenAPI 3.0', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.3'
+			})
+		)
+
+		app.get('/nullable-30', () => 'hello', {
+			response: t.Union([t.String(), t.Null()])
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		const response = res.paths['/nullable-30'].get.responses['200']
+		const schema =
+			response.content?.['application/json']?.schema ??
+			response.content?.['text/plain']?.schema
+
+		expect(schema).toBeDefined()
+		expect(schema.type).toBe('string')
+		expect(schema.nullable).toBe(true)
+		expect(schema.anyOf).toBeUndefined()
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('treats null response as nullable schema for OpenAPI 3.0', async () => {
+		const app = new Elysia().use(
+			openapi({
+				openapiVersion: '3.0.3'
+			})
+		)
+
+		app.get('/null-30', () => null, {
+			response: t.Null()
+		})
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json')).then((x) => x.json())
+		const schema =
+			res.paths['/null-30'].get.responses['200'].content[
+				'application/json'
+			].schema
+
+		expect(schema.nullable).toBe(true)
+		expect(schema.type).toBeUndefined()
+		await SwaggerParser.validate(res).catch((err) => fail(err))
+	})
+
+	it('use custom Swagger-UI version', async () => {
 		const app = new Elysia().use(
 			openapi({
 				provider: 'swagger-ui',
@@ -125,6 +322,53 @@ describe('Swagger', () => {
 
 		const resJson = await app.handle(req('/v2/openapi/json'))
 		expect(resJson.status).toBe(200)
+	})
+
+	it('uses absolute URL for custom absolute specPath', async () => {
+		const app = new Elysia().use(
+			openapi({
+				path: '/api/v1/docs',
+				specPath: '/api/v1/openapi.json'
+			})
+		)
+
+		await app.modules
+
+		const page = await app.handle(req('/api/v1/docs')).then((x) => x.text())
+		expect(page).toContain('"url":"/api/v1/openapi.json"')
+
+		const spec = await app.handle(req('/api/v1/openapi.json'))
+		expect(spec.status).toBe(200)
+	})
+
+	it('keeps relative URL for default specPath pattern', async () => {
+		const app = new Elysia().use(
+			openapi({
+				path: '/api/docs'
+			})
+		)
+
+		await app.modules
+
+		const page = await app.handle(req('/api/docs')).then((x) => x.text())
+		expect(page).toContain('"url":"api/docs/json"')
+
+		const spec = await app.handle(req('/api/docs/json'))
+		expect(spec.status).toBe(200)
+	})
+
+	it('keeps default spec URLs separate for multiple docs instances', async () => {
+		const app = new Elysia()
+			.use(openapi({ provider: 'swagger-ui', path: '/docs/v1' }))
+			.use(openapi({ provider: 'scalar', path: '/docs/v2' }))
+
+		await app.modules
+
+		const swagger = await app.handle(req('/docs/v1')).then((x) => x.text())
+		const scalar = await app.handle(req('/docs/v2')).then((x) => x.text())
+
+		expect(swagger).toContain('"url":"docs/v1/json"')
+		expect(scalar).toContain('"url":"docs/v2/json"')
 	})
 
 	it('Swagger UI options', async () => {
@@ -272,4 +516,38 @@ describe('Swagger', () => {
 		const response = await res.json()
 		expect(Object.keys(response.paths['/all'])).toBeArrayOfSize(8)
 	})
+
+	// https://github.com/elysiajs/elysia-openapi/issues/273
+  it('should exclude routes with specified tags', async () => {
+    const app = new Elysia()
+      .use(
+        openapi({
+          exclude: {
+            tags: ['internal']
+          }
+        })
+      )
+      .get('/', () => 'index')
+      .get('/healthz', () => ({ status: 'ok' }), {
+        detail: {
+          tags: ['internal']
+        }
+      })
+
+    await app.modules
+
+		const res = await app.handle(req('/openapi/json'))
+		expect(res.status).toBe(200)
+		const response = await res.json()
+
+    // Check that only root path is included
+    expect(Object.keys(response.paths)).toEqual(['/'])
+
+    // Verify /healthz is excluded
+    expect(response.paths['/healthz']).toBeUndefined()
+
+    // Verify root path is included and has GET method
+    expect(response.paths['/']).toBeDefined()
+    expect(response.paths['/'].get).toBeDefined()
+  })
 })

--- a/test/openapi/enum-to-openapi.test.ts
+++ b/test/openapi/enum-to-openapi.test.ts
@@ -54,4 +54,78 @@ describe('OpenAPI > enumToOpenAPI', () => {
 
 		expect(result).toEqual(expectedSchema)
 	})
+
+	it('should replace {"type":"Date"} with {"type":"string","format":"date-time"} and deduplicate', () => {
+		// TypeBox t.Date() expands to this anyOf; "Date" is not a valid OpenAPI type
+		const schema = {
+			anyOf: [
+				{ type: 'Date' },
+				{ format: 'date-time', type: 'string' },
+				{ format: 'date', type: 'string' },
+				{ type: 'number' }
+			]
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		// The invalid Date entry is replaced; the duplicate date-time is removed
+		expect(result.anyOf).not.toContainEqual({ type: 'Date' })
+		expect(result.anyOf.filter((x: any) => x.type === 'string' && x.format === 'date-time')).toHaveLength(1)
+		expect(result.anyOf).toContainEqual({ type: 'string', format: 'date-time' })
+	})
+
+	it('should preserve {"type":"null"} sibling when replacing Date in a nullable date field', () => {
+		// t.Nullable(t.Date()) -- after plugin processing -- can appear as this flat anyOf
+		const schema = {
+			anyOf: [{ type: 'Date' }, { type: 'null' }]
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		expect(result.anyOf).toContainEqual({ type: 'string', format: 'date-time' })
+		expect(result.anyOf).toContainEqual({ type: 'null' })
+		expect(result.anyOf).not.toContainEqual({ type: 'Date' })
+	})
+
+	it('should fix Date types nested in object properties', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				createdAt: {
+					anyOf: [
+						{ type: 'Date' },
+						{ format: 'date-time', type: 'string' },
+						{ format: 'date', type: 'string' },
+						{ type: 'number' }
+					]
+				}
+			}
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		expect(result.properties.createdAt.anyOf).not.toContainEqual({ type: 'Date' })
+		expect(result.properties.createdAt.anyOf).toContainEqual({
+			type: 'string',
+			format: 'date-time'
+		})
+	})
+
+	it('should fix Date types nested in array items', () => {
+		const schema = {
+			type: 'array',
+			items: {
+				anyOf: [
+					{ type: 'Date' },
+					{ format: 'date-time', type: 'string' }
+				]
+			}
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		// Both entries normalise to date-time; dedup collapses anyOf to a bare schema
+		expect(result.items).toEqual({ type: 'string', format: 'date-time' })
+	})
 })

--- a/test/openapi/enum-to-openapi.test.ts
+++ b/test/openapi/enum-to-openapi.test.ts
@@ -87,6 +87,23 @@ describe('OpenAPI > enumToOpenAPI', () => {
 		expect(result.anyOf).not.toContainEqual({ type: 'Date' })
 	})
 
+	it('should preserve top-level metadata when deduplicating anyOf to one schema', () => {
+		const schema = {
+			description: 'Creation timestamp',
+			title: 'CreatedAt',
+			anyOf: [{ type: 'Date' }, { format: 'date-time', type: 'string' }]
+		}
+
+		const result = enumToOpenApi(schema as any) as any
+
+		expect(result).toEqual({
+			description: 'Creation timestamp',
+			title: 'CreatedAt',
+			type: 'string',
+			format: 'date-time'
+		})
+	})
+
 	it('should fix Date types nested in object properties', () => {
 		const schema = {
 			type: 'object',

--- a/test/openapi/null-to-openapi.test.ts
+++ b/test/openapi/null-to-openapi.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test'
+import { t } from 'elysia'
+
+import { nullToOpenApi } from '../../src/openapi'
+
+describe('OpenAPI > nullToOpenAPI', () => {
+	it('converts nullable union to nullable:true for OAS 3.0', () => {
+		const schema = t.Object({
+			promo_code: t.Optional(
+				t.Union([t.String({ example: 'SUMMER20' }), t.Null()])
+			)
+		})
+
+		const result = nullToOpenApi(schema as any, '3.0.3') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: 'string',
+			example: 'SUMMER20',
+			nullable: true
+		})
+	})
+
+	it('converts nullable union to type:[string, null] for OAS 3.1', () => {
+		const schema = t.Object({
+			promo_code: t.Optional(
+				t.Union([t.String({ example: 'SUMMER20' }), t.Null()])
+			)
+		})
+
+		const result = nullToOpenApi(schema as any, '3.1.2') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: ['string', 'null'],
+			example: 'SUMMER20'
+		})
+		expect(result.properties.promo_code.nullable).toBeUndefined()
+	})
+
+	it('does not treat metadata objects like default as schemas in OAS 3.0', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				promo_code: {
+					anyOf: [{ type: 'string' }, { type: 'null' }]
+				}
+			},
+			default: {
+				type: 'null',
+				reason: 'metadata'
+			}
+		}
+
+		const result = nullToOpenApi(schema as any, '3.0.3') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: 'string',
+			nullable: true
+		})
+		expect(result.default).toEqual({
+			type: 'null',
+			reason: 'metadata'
+		})
+	})
+
+	it('does not treat metadata objects like default as schemas in OAS 3.1', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				promo_code: {
+					anyOf: [{ type: 'string' }, { type: 'null' }]
+				}
+			},
+			default: {
+				type: 'null',
+				reason: 'metadata'
+			}
+		}
+
+		const result = nullToOpenApi(schema as any, '3.1.2') as any
+
+		expect(result.properties.promo_code).toMatchObject({
+			type: ['string', 'null']
+		})
+		expect(result.default).toEqual({
+			type: 'null',
+			reason: 'metadata'
+		})
+	})
+})

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'bun:test'
 import { AnyElysia, Elysia, t } from 'elysia'
 
-import { toOpenAPISchema } from '../../src/openapi'
+import { toOpenAPISchema, withHeaders } from '../../src/openapi'
 import { z } from 'zod'
+import { type } from 'arktype'
 
 const is = <T extends AnyElysia>(
 	app: T,
@@ -229,6 +230,39 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		})
 	})
 
+	it('handle arrayBuffer request body', () => {
+		const app = new Elysia().post('/upload', () => 'ok', {
+			parse: 'arrayBuffer',
+			body: t.Any({
+				description: 'Binary file data'
+			})
+		})
+
+		is(app, {
+			components: {
+				schemas: {}
+			},
+			paths: {
+				'/upload': {
+					post: {
+						operationId: 'postUpload',
+						requestBody: {
+							description: 'Binary file data',
+							content: {
+								'application/octet-stream': {
+									schema: {
+										description: 'Binary file data'
+									}
+								}
+							},
+							required: true
+						}
+					}
+				}
+			}
+		})
+	})
+
 	it('handle response', () => {
 		const app = new Elysia().get(
 			'/user',
@@ -271,6 +305,37 @@ describe('OpenAPI > toOpenAPISchema', () => {
 				}
 			}
 		})
+	})
+
+	it('handle response headers', () => {
+		const app = new Elysia().get(
+			'/user',
+			() => ({ name: 'Lilith' }) as const,
+			{
+				response: withHeaders(
+					t.Object({
+						name: t.Literal('Lilith')
+					}),
+					{
+						'x-request-id': t.String()
+					}
+				)
+			}
+		)
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+		const response = schema.paths['/user'].get.responses['200']
+
+		expect(response.headers).toEqual({
+			'x-request-id': {
+				schema: {
+					type: 'string'
+				}
+			}
+		})
+		expect(
+			response.content['application/json'].schema.headers
+		).toBeUndefined()
 	})
 
 	it('handle multiple response status', () => {
@@ -337,6 +402,72 @@ describe('OpenAPI > toOpenAPISchema', () => {
 				}
 			}
 		})
+	})
+
+	it('handle response headers on multiple status responses', () => {
+		const app = new Elysia().get(
+			'/user',
+			() => ({ name: 'Lilith' }) as const,
+			{
+				response: {
+					200: withHeaders(
+						t.Object({
+							name: t.Literal('Fouco')
+						}),
+						{
+							'x-rate-limit': t.Number()
+						}
+					),
+					404: t.Object({
+						name: t.Literal('Lilith')
+					})
+				}
+			}
+		)
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+		const responses = schema.paths['/user'].get.responses
+
+		expect(responses['200'].headers).toEqual({
+			'x-rate-limit': {
+				schema: {
+					type: 'number'
+				}
+			}
+		})
+		expect(responses['404'].headers).toBeUndefined()
+	})
+
+	it('does not mutate reused response schema when adding headers', () => {
+		const response = t.Object({
+			name: t.String()
+		})
+
+		const app = new Elysia()
+			.get('/with-headers', () => ({ name: 'Lilith' }), {
+				response: withHeaders(response, {
+					'x-request-id': t.String()
+				})
+			})
+			.get('/without-headers', () => ({ name: 'Lilith' }), {
+				response
+			})
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect('headers' in response).toBe(false)
+		expect(
+			schema.paths['/with-headers'].get.responses['200'].headers
+		).toEqual({
+			'x-request-id': {
+				schema: {
+					type: 'string'
+				}
+			}
+		})
+		expect(
+			schema.paths['/without-headers'].get.responses['200'].headers
+		).toBeUndefined()
 	})
 
 	it('handle every parameters together', () => {
@@ -794,6 +925,31 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		})
 	})
 
+	it('normalizes nested TypeBox refs', () => {
+		const app = new Elysia()
+			.model(
+				'user',
+				t.Object({
+					name: t.String()
+				})
+			)
+			.get('/profile', () => ({ user: { name: 'Lilith' } }), {
+				response: t.Object({
+					user: t.Ref('user')
+				})
+			})
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect(
+			schema.paths['/profile'].get.responses['200'].content[
+				'application/json'
+			].schema.properties.user
+		).toEqual({
+			$ref: '#/components/schemas/user'
+		})
+	})
+
 	it('reference multiple response', () => {
 		const model = new Elysia().model({
 			lilith: t.Object({
@@ -1093,6 +1249,23 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		})
 	})
 
+	it('keeps dotted API paths while excluding file-like static paths', () => {
+		const app = new Elysia()
+			.get('/test.2', () => 'hello')
+			.group('/v1.2', (app) =>
+				app.get('/test', () => ({
+					status: 'ok'
+				}))
+			)
+			.get('/favicon.ico', () => 'icon')
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect(schema.paths['/test.2']).toBeDefined()
+		expect(schema.paths['/v1.2/test']).toBeDefined()
+		expect(schema.paths['/favicon.ico']).toBeUndefined()
+	})
+
 	it('response accept annotation', () => {
 		const model = new Elysia().model({
 			lilith: t.Object(
@@ -1275,5 +1448,158 @@ describe('OpenAPI > toOpenAPISchema', () => {
 				}
 			}
 		})
+	})
+
+	it('include body schema when parse is "none"', () => {
+		const app = new Elysia().post(
+			'/echo',
+			({ request }) => request,
+			{
+				body: t.Object({ input: t.String() }),
+				parse: 'none'
+			}
+		)
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect(schema.paths['/echo'].post.requestBody).toBeDefined()
+		expect(schema.paths['/echo'].post.requestBody.content).toBeDefined()
+		expect(
+			schema.paths['/echo'].post.requestBody.content['application/json']
+		).toBeDefined()
+		expect(
+			schema.paths['/echo'].post.requestBody.content['application/json'].schema
+		).toEqual({
+			type: 'object',
+			properties: {
+				input: { type: 'string' }
+			},
+			required: ['input']
+		})
+	})
+})
+
+describe('OpenAPI > ArkType', () => {
+	// ArkType emits the JSON Schema `$schema` dialect on each converted schema.
+	const $schema = 'https://json-schema.org/draft/2020-12/schema'
+
+	// Body schemas are mirrored across every accepted content type.
+	const body = (s: Record<string, unknown>) => ({
+		content: {
+			'application/json': { schema: s },
+			'application/x-www-form-urlencoded': { schema: s },
+			'multipart/form-data': { schema: s }
+		},
+		required: true
+	})
+
+	const doc = (app: AnyElysia) =>
+		JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+	// https://github.com/elysiajs/elysia/issues/1844
+	it('degrades a predicate (string.date) instead of dropping the schema', () => {
+		const app = new Elysia().post('/bug', () => 'ok', {
+			body: type({ date: 'string.date' })
+		})
+
+		is(app, {
+			components: { schemas: {} },
+			paths: {
+				'/bug': {
+					post: {
+						operationId: 'postBug',
+						requestBody: body({
+							$schema,
+							type: 'object',
+							properties: { date: { type: 'string' } },
+							required: ['date']
+						})
+					}
+				}
+			}
+		})
+	})
+
+	it('maps a Date to string/date-time', () => {
+		const app = new Elysia().post('/at', () => 'ok', {
+			body: type({ at: 'Date' })
+		})
+
+		is(app, {
+			components: { schemas: {} },
+			paths: {
+				'/at': {
+					post: {
+						operationId: 'postAt',
+						requestBody: body({
+							$schema,
+							type: 'object',
+							properties: {
+								at: { type: 'string', format: 'date-time' }
+							},
+							required: ['at']
+						})
+					}
+				}
+			}
+		})
+	})
+
+	it('leaves a predicate-free schema unchanged', () => {
+		const app = new Elysia().post('/plain', () => 'ok', {
+			body: type({ name: 'string', age: 'number' })
+		})
+
+		expect(
+			doc(app).paths['/plain'].post.requestBody.content[
+				'application/json'
+			].schema
+		).toEqual({
+			$schema,
+			type: 'object',
+			properties: { name: { type: 'string' }, age: { type: 'number' } },
+			required: ['age', 'name']
+		})
+	})
+
+	// Morphs (e.g. `string.date.parse`) previously threw `code: "morph"` and
+	// dropped the schema; the `default` fallback degrades them to the base type.
+	it('degrades a morph (string.date.parse) instead of dropping the schema', () => {
+		const app = new Elysia().post('/morph', () => 'ok', {
+			body: type({ when: 'string.date.parse' })
+		})
+
+		const op = doc(app).paths['/morph'].post
+
+		expect(op.requestBody).toBeDefined()
+		expect(
+			op.requestBody.content['application/json'].schema.properties.when
+		).toEqual({ type: 'string' })
+	})
+
+	it('lets a user-supplied mapJsonSchema.arktype override win', () => {
+		const app = new Elysia().post('/override', () => 'ok', {
+			body: type({ date: 'string.date' })
+		})
+
+		const override = {
+			type: 'object',
+			properties: { date: { type: 'string', format: 'overridden' } },
+			required: ['date']
+		}
+
+		const result = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(app, undefined, undefined, {
+					arktype: () => override
+				})
+			)
+		)
+
+		expect(
+			result.paths['/override'].post.requestBody.content[
+				'application/json'
+			].schema
+		).toEqual(override)
 	})
 })

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -1266,6 +1266,25 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		expect(schema.paths['/favicon.ico']).toBeUndefined()
 	})
 
+	it('keeps regex path exclusion stable for global patterns', () => {
+		const app = new Elysia()
+			.get('/internal/a', () => 'hidden')
+			.get('/internal/b', () => 'hidden')
+			.get('/public', () => 'visible')
+
+		const schema = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(app, {
+					paths: [/^\/internal/g]
+				})
+			)
+		)
+
+		expect(schema.paths['/internal/a']).toBeUndefined()
+		expect(schema.paths['/internal/b']).toBeUndefined()
+		expect(schema.paths['/public']).toBeDefined()
+	})
+
 	it('response accept annotation', () => {
 		const model = new Elysia().model({
 			lilith: t.Object(


### PR DESCRIPTION
## Summary

This PR bundles OpenAPI 3.1 support and a set of small, tested stabilization fixes into one clean branch based on the current upstream `main`.

It intentionally does **not** include ONREZA fork-only package naming, release, npm publishing, or repository metadata changes.

Main changes:

- add configurable OpenAPI `3.0.x` / `3.1.x` output via `openapiVersion`
- normalize nullable schemas for OpenAPI 3.0 vs 3.1 output
- normalize Date schemas to `string` / `date-time`
- preserve ArkType predicate and morph schemas instead of dropping them
- include request body schemas for `parse: "none"` and `ArrayBuffer`
- support `RegExp` path exclusion and dotted API paths while still excluding static files
- handle `exclude.tags` safely when routes do not define tags
- keep repeated documentation requests, custom absolute `specPath`, and multiple docs instances stable
- emit response headers declared with `withHeaders` without mutating reused schemas
- normalize nested TypeBox refs inside generated schemas
- add `x-tagGroups` documentation type support
- improve `fromTypes` parsing for alphanumeric route keys, digit-ending route segments, aliases, nested intersections, `import("...").TypeName`, and compiler option merging
- bump `actions/checkout` and `oven-sh/setup-bun` in existing workflows

## Issue / PR mapping

Closes 5 open issues:

Closes #145
Closes #330
Closes #331
Closes #339
Closes #345

Maps / supersedes 11 open PRs:

- #187 - Scalar custom theme should not be overridden by default CSS
- #201 - `x-tagGroups` support
- #222 - node adapter response reuse fix
- #224 - Swagger white page / repeated docs page handling
- #238 - `oven-sh/setup-bun` workflow bump
- #243 - absolute / relative `specPath` handling
- #290 - type-gen support for alphanumeric paths
- #302 - `actions/checkout` workflow bump
- #329 - `fromTypes` numeric keys, aliases, and import resolution
- #334 - headers from `withHeaders`
- #337 - TypeBox component reference normalization

## Validation

- `bun install --frozen-lockfile`
- `bun build.ts`
- `npm test` - 102 tests passing, including CJS/ESM Node smoke tests
- `npm pack --dry-run`
- whitespace check with `cr-at-eol` enabled for the existing CRLF `build.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenAPI version support (3.0.x and 3.1.x) with improved spec generation, including tag-group documentation and smarter spec URL handling.
* **Bug Fixes**
  * Improved schema normalization for nullables and Dates (including correct date-time formatting), response/header shaping, and route/tag/exclude filtering.
  * Corrected Scalar rendering CSS fallback behavior and prevented header wrapper mutations.
* **Documentation**
  * Updated README OpenAPI configuration examples and spec references.
* **Tests**
  * Expanded coverage for OpenAPI output differences and edge cases across providers and content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->