### PR TITLE
fix: make exclude.paths support regexes according to existing types

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -719,7 +719,10 @@ export function toOpenAPISchema(
 		if (
 			(excludeStaticFile && route.path.includes('.')) ||
 			excludePaths.some((exclusion) => {
-				if (exclusion instanceof RegExp) return exclusion.test(route.path)
+				if (exclusion instanceof RegExp) {
+					exclusion.lastIndex = 0
+					return exclusion.test(route.path)
+				}
 				if (typeof exclusion === 'string') return exclusion === route.path
 				return false
 			}) ||

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -718,7 +718,11 @@ export function toOpenAPISchema(
 
 		if (
 			(excludeStaticFile && route.path.includes('.')) ||
-			excludePaths.includes(route.path) ||
+			excludePaths.some((exclusion) => {
+				if (exclusion instanceof RegExp) return exclusion.test(route.path)
+				if (typeof exclusion === 'string') return exclusion === route.path
+				return false
+			}) ||
 			excludeMethods.includes(method)
 		)
 			continue

--- a/test/openapi/exclude-paths.test.ts
+++ b/test/openapi/exclude-paths.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'bun:test'
+import { Elysia } from 'elysia'
+
+import { toOpenAPISchema } from '../../src/openapi'
+
+const getPathKeys = (app: Elysia, exclude?: Parameters<typeof toOpenAPISchema>[1]) =>
+	Object.keys(toOpenAPISchema(app, exclude).paths)
+
+const app = new Elysia()
+	.get('/users', () => 'ok')
+	.get('/users/:id', () => 'ok')
+	.get('/posts', () => 'ok')
+	.get('/posts/:id', () => 'ok')
+	.get('/health', () => 'ok')
+
+describe('OpenAPI > exclude.paths', () => {
+	it('includes all paths when exclude.paths is undefined', () => {
+		const paths = getPathKeys(app, { paths: undefined })
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+		expect(paths).toContain('/posts')
+		expect(paths).toContain('/posts/{id}')
+		expect(paths).toContain('/health')
+	})
+
+	it('excludes a single string path', () => {
+		const paths = getPathKeys(app, { paths: '/health' })
+		expect(paths).not.toContain('/health')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/posts')
+	})
+
+	it('excludes multiple string paths in an array', () => {
+		const paths = getPathKeys(app, { paths: ['/health', '/posts'] })
+		expect(paths).not.toContain('/health')
+		expect(paths).not.toContain('/posts')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/posts/{id}')
+	})
+
+	it('excludes paths matching a single RegExp', () => {
+		const paths = getPathKeys(app, { paths: /^\/posts/ })
+		expect(paths).not.toContain('/posts')
+		expect(paths).not.toContain('/posts/{id}')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+		expect(paths).toContain('/health')
+	})
+
+	it('excludes paths matching any RegExp in an array', () => {
+		const paths = getPathKeys(app, { paths: [/^\/posts/, /^\/health/] })
+		expect(paths).not.toContain('/posts')
+		expect(paths).not.toContain('/posts/{id}')
+		expect(paths).not.toContain('/health')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+	})
+
+	it('excludes paths matching a mixed (string | RegExp)[] array', () => {
+		const paths = getPathKeys(app, { paths: ['/health', /^\/posts/] })
+		expect(paths).not.toContain('/health')
+		expect(paths).not.toContain('/posts')
+		expect(paths).not.toContain('/posts/{id}')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+	})
+
+	it('does not exclude paths that only partially match a string', () => {
+		const paths = getPathKeys(app, { paths: '/post' })
+		// '/post' should not exclude '/posts' or '/posts/:id'
+		expect(paths).toContain('/posts')
+		expect(paths).toContain('/posts/{id}')
+	})
+
+	it('does not exclude paths that do not match a RegExp', () => {
+		const paths = getPathKeys(app, { paths: /^\/admin/ })
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+		expect(paths).toContain('/posts')
+		expect(paths).toContain('/posts/{id}')
+		expect(paths).toContain('/health')
+	})
+
+	it('excludes exact string matches only', () => {
+		const paths = getPathKeys(app, { paths: ['/users', '/posts/:id'] })
+		expect(paths).not.toContain('/users')
+		expect(paths).not.toContain('/posts/{id}')
+		expect(paths).toContain('/users/{id}')
+		expect(paths).toContain('/posts')
+		expect(paths).toContain('/health')
+	})
+})

--- a/test/openapi/exclude-paths.test.ts
+++ b/test/openapi/exclude-paths.test.ts
@@ -47,6 +47,15 @@ describe('OpenAPI > exclude.paths', () => {
 		expect(paths).toContain('/health')
 	})
 
+	it('excludes all matching routes with a global RegExp', () => {
+		const paths = getPathKeys(app, { paths: /^\/posts/g })
+		expect(paths).not.toContain('/posts')
+		expect(paths).not.toContain('/posts/{id}')
+		expect(paths).toContain('/users')
+		expect(paths).toContain('/users/{id}')
+		expect(paths).toContain('/health')
+	})
+
 	it('excludes paths matching any RegExp in an array', () => {
 		const paths = getPathKeys(app, { paths: [/^\/posts/, /^\/health/] })
 		expect(paths).not.toContain('/posts')


### PR DESCRIPTION
## Bug

In `src/types.ts`, the `ElysiaOpenAPIConfig.exclude.paths` type is defined as follows:

```ts
/**
 * Paths to exclude from OpenAPI endpoint
 *
 * @default []
 */
paths?: string | RegExp | (string | RegExp)[]
```

The existing implementation converts this to an array (`const excludePaths: (string | RegExp)[]`). However, the exclusion check in `src/openapi.ts` on line 721 only uses `excludePaths.includes(route.path)` which **only works for strings, not for regexes**.

## Fix

This pull request fixes that by using the following check instead. This fix now makes `exclude.paths` work according to the existing type declaration.

```ts
excludePaths.some((exclusion) => {
    if (exclusion instanceof RegExp) return exclusion.test(route.path)
    if (typeof exclusion === 'string') return exclusion === route.path
    return false
})
```

> **Edit** (Credit to CodeRabbit for catching this bug)
> 
> Added `exclusion.lastIndex = 0` to reset the state of the RegExp before running `return exclusion.test(route.path)` (incl. tests for bugs due to RegExp state not being reset).
>
> Not resetting `lastIndex` caused e.g. `/^\/posts/g` to not match `'/posts/{id}'` if it had checked `'/posts'` before.

This implementation pattern makes it easy to extend in the future, for example if string glob patterns (e.g. `/api/secret/*`) are ever implemented.

## Tests

There is a new `test/openapi/exclude-paths.test.ts` to ensure that the `exclude.paths` property works as intended for undefined, strings, RegExp, and arrays mixing either strings or RegExps. **All tests pass**.

> AI Disclaimer: Coding Agents were only used to implement the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI route exclusions now support both exact path strings and regular expression patterns.
  * Improved filtering ensures partial or non-matching exclusions do not remove unrelated routes.
  * Template-based route paths are handled with exact matching.

* **Tests**
  * Added coverage for single and multiple string exclusions, regular expressions, mixed patterns, and non-matching exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->