### PR TITLE
fix: resolve typebox from packaged openapi generator

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -11,6 +11,9 @@ await build({
 	format: ['esm', 'cjs'],
 	minify: false,
 	unbundle: true,
+	deps: {
+		neverBundle: true
+	},
 	dts: true,
 	outExtensions(c) {
 		return {
@@ -19,3 +22,10 @@ await build({
 		}
 	}
 })
+
+for (const format of ['index.mjs', 'index.js']) {
+	const generatedEntry = await Bun.file(`dist/gen/${format}`).text()
+
+	if (generatedEntry.includes('../node_modules/typebox/'))
+		throw new Error('Build emitted a package-relative TypeBox import')
+}

--- a/package.json
+++ b/package.json
@@ -84,11 +84,13 @@
         "file-type": "^22.0.0",
         "openapi-types": "^12.1.3",
         "tsdown": "^0.22.3",
-        "typebox": "1.3.0",
         "typescript": "^5.9.2",
         "zod": "^4.2.1"
     },
     "peerDependencies": {
         "elysia": ">= 2.0.0-beta.1"
+    },
+    "dependencies": {
+        "typebox": "1.3.0"
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `@elysia/openapi@2.0.0-beta.1` package failure reported in [elysiajs/elysia#1963](https://github.com/elysiajs/elysia/issues/1963).

The beta build bundled TypeBox into `dist/node_modules` and emitted `../node_modules/typebox/...` from `dist/gen/index.mjs`. From an installed package, that relative path resolves under `dist/node_modules`, which is not included in the published artifact, so Bun fails before the plugin can load.

## Changes

- Externalize runtime dependencies during the package build, preserving the `typebox/type` import instead of generating a path into `dist/node_modules`.
- Move `typebox` from `devDependencies` to `dependencies`, since `Script` is used at runtime by the generator.
- Add a post-build guard for both ESM and CommonJS generator entries so a package-relative TypeBox import fails the build rather than being published.

## Verification

- Reproduced the original failure with Bun `1.3.14`, `elysia@2.0.0-beta.4`, and `@elysia/openapi@2.0.0-beta.1`.
- `bun run build`
- `bun run test` — 59 Bun tests passed, plus the existing Node CommonJS and ESM package checks.
- Packed the modified package and installed it into a clean project using the reporter's exact Bun and Elysia beta versions. `new Elysia().use(openapi())` now imports successfully.

The affected code is maintained in this package repository; the original report was opened in `elysiajs/elysia` because the failure appears while using Elysia.