### PR TITLE
fix: return a fresh OpenAPI page response in dynamic mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,29 +9,6 @@ import type { OpenAPIV3 } from 'openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { ElysiaOpenAPIConfig } from './types'
 
-function isCloudflareWorker() {
-	try {
-		// Check for the presence of caches.default, which is a global in Workers
-		if (
-			// @ts-ignore
-			typeof caches !== 'undefined' &&
-			// @ts-ignore
-			typeof caches.default !== 'undefined'
-		)
-			return true
-
-		// @ts-ignore
-		if (typeof WebSocketPair !== 'undefined') {
-			return true
-		}
-	} catch (e) {
-		// If accessing these globals throws an error, it's likely not a Worker
-		return false
-	}
-
-	return false
-}
-
 /**
  * Plugin for [elysia](https://github.com/elysiajs/elysia) that auto-generate OpenAPI documentation page.
  *
@@ -147,7 +124,7 @@ export const openapi = <
 
 		return app.get(
 			path,
-			embedSpec || isCloudflareWorker() ? page : page(),
+			page,
 			{
 				detail: {
 					hide: true

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,6 +17,18 @@ describe('Swagger', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('show OpenAPI page repeatedly in dynamic mode', async () => {
+		const app = new Elysia({ aot: false }).use(openapi())
+
+		await app.modules
+
+		for (let requestNumber = 0; requestNumber < 2; requestNumber++) {
+			const res = await app.handle(req('/openapi'))
+			expect(res.status).toBe(200)
+			expect(await res.text()).toContain('<title>Elysia Documentation</title>')
+		}
+	})
+
 	it('returns a valid OpenAPI json config', async () => {
 		const app = new Elysia().use(openapi())
 


### PR DESCRIPTION
## Problem

When Elysia runs with `aot: false`, repeated requests to the OpenAPI UI can fail after the first response body is consumed.

The plugin currently evaluates `page()` while it registers the route when `embedSpec` is disabled outside Cloudflare Workers. This stores one `Response` instance as the route value. Dynamic mode returns that same instance again, but its body is already disturbed or locked. Depending on the adapter path, the request fails with `TypeError: Body already used` or `TypeError: Body object should not be disturbed or locked`.

## Fix

Register `page` as the route handler in every environment. Elysia now calls the function for each request, so each request receives a new `Response` with an unread body. The Cloudflare-specific check is no longer necessary because every runtime uses the safe handler path.

## Regression test

The new test creates an Elysia app with `aot: false`, requests `/openapi` twice, consumes both response bodies, and verifies that both responses contain the documentation page.

## Verification

- `bun run test`: 59 tests passed
- CommonJS Node.js compatibility passed
- ESM Node.js compatibility passed
- `bun run build` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the OpenAPI documentation page in dynamic mode.
  * Ensured repeated requests to the documentation page load successfully and display the expected title.
  * Simplified route handling for more consistent OpenAPI page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->