### PR TITLE
feat(openapi): add 3.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Enable/Disable the plugin
 
 @default '3.1.2'
 
-OpenAPI document version to emit. Supports OpenAPI `3.0.x` and `3.1.x`.
+OpenAPI document version to emit. Supports OpenAPI `3.0.x`, `3.1.x`, and
+`3.2.x`.
 
 ## documentation
 
@@ -72,13 +73,19 @@ OpenAPI documentation information
 
 @see https://spec.openapis.org/oas/latest.html
 
+OpenAPI 3.2 documentation supports `$self`, named servers, nested tags,
+`components.mediaTypes`, streaming media metadata, new security fields,
+`QUERY`, and `additionalOperations`.
+
 ## exclude
 
 Configuration to exclude paths or methods from documentation
 
 ## exclude.methods
 
-List of methods to exclude from documentation
+List of methods to exclude from documentation. In OpenAPI 3.2, `QUERY` is a
+normal Path Item operation and other HTTP methods are emitted under
+`additionalOperations`.
 
 ## exclude.paths
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,15 @@
     "": {
       "name": "@elysiajs/openapi",
       "devDependencies": {
-        "@apidevtools/swagger-parser": "^12.1.0",
-        "@scalar/types": "^0.2.16",
+        "@apidevtools/swagger-parser": "^13.0.0",
+        "@scalar/openapi-parser": "^0.29.0",
+        "@scalar/openapi-types": "^0.9.5",
+        "@scalar/types": "^0.18.3",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
         "effect": "^3.21.2",
         "elysia": "1.4.25",
         "eslint": "9.6.0",
-        "openapi-types": "^12.1.3",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "zod": "^4.3.6",
@@ -25,13 +26,13 @@
     },
   },
   "packages": {
-    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.0.1", "", { "dependencies": { "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw=="],
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@15.3.6", "", { "dependencies": { "js-yaml": "^4.2.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw=="],
 
     "@apidevtools/openapi-schemas": ["@apidevtools/openapi-schemas@2.1.0", "", {}, "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="],
 
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
 
-    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@12.1.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "14.0.1", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng=="],
+    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@13.0.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "15.3.6", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "@types/json-schema": "^7.0.15", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-TcvnmBzJD7DBREkc/2qaxMqbKpttOaHhOFsYRYKdYAv6HGY+iNlWY2IUA209C2/NmvL9z8RBZhkrESqvGkjqmw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
@@ -161,9 +162,21 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.5", "", { "os": "win32", "cpu": "x64" }, "sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ=="],
 
-    "@scalar/openapi-types": ["@scalar/openapi-types@0.3.7", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QHSvHBVDze3+dUwAhIGq6l1iOev4jdoqdBK7QpfeN1Q4h+6qpVEw3EEqBiH0AXUSh/iWwObBv4uMgfIx0aNZ5g=="],
+    "@scalar/helpers": ["@scalar/helpers@0.11.2", "", {}, "sha512-IgHW/hIj1XAvsPIBKiOgmK87qbyDjaQQg9S/auXU4MUtvnwKKpOeIOJc0NC71FkMdr4Mok0SSVI748cmlptoXQ=="],
 
-    "@scalar/types": ["@scalar/types@0.2.16", "", { "dependencies": { "@scalar/openapi-types": "0.3.7", "nanoid": "5.1.5", "zod": "3.24.1" } }, "sha512-XWff9jWfYaj6q3ww94x66S6Q58u/3kA1sDOUhLAwb9va7r58bzk3NRwLOkEEdJmyEns1MEJAM53mY8KRWX6elA=="],
+    "@scalar/json-magic": ["@scalar/json-magic@0.13.3", "", { "dependencies": { "@scalar/helpers": "0.11.2", "pathe": "^2.0.3", "yaml": "^2.9.0" } }, "sha512-ONbveMHPl8ashCnTH/IzF2skr7CKUAC97m2tWQpbWJXhkUvc/B9vSRirjM0IqPCDURn4WZWAQFoaehDiEJICWA=="],
+
+    "@scalar/json-schema-validator": ["@scalar/json-schema-validator@0.1.0", "", { "dependencies": { "@scalar/helpers": "0.11.2", "@scalar/types": "0.18.3", "ajv": "^8.20.0", "ajv-draft-04": "^1.0.0", "ajv-formats": "^3.0.1", "yaml": "^2.9.0" } }, "sha512-3mOin8TlRqhH9CndcZeOGFicb+/WSPmclko7vnaTIIa8vqrwZ6ZtwLdsZQpU1xzM5NqMgumF35ii3KEPS7kNDA=="],
+
+    "@scalar/openapi-parser": ["@scalar/openapi-parser@0.29.0", "", { "dependencies": { "@scalar/helpers": "0.11.2", "@scalar/json-magic": "0.13.3", "@scalar/openapi-types": "0.9.5", "@scalar/openapi-upgrader": "0.2.15", "@scalar/openapi-validator": "0.1.0", "@scalar/types": "0.18.3", "yaml": "^2.9.0" } }, "sha512-RVPVidIG5ohEUqPdB70kabhvAP1wq54iWwwdD9TKfJC73OSGUW2+7sHPFEwAD2MIwX9iDMOtxlSIHIk8Lidwdw=="],
+
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.9.5", "", {}, "sha512-czrz/zkVm1oPzrpYo3hI/iymfiw1s4dgJiQtwNi2U77Sqf3EQOGKsif4VNRa5suWMYRuPaFx5EiFM1FNEV4Whg=="],
+
+    "@scalar/openapi-upgrader": ["@scalar/openapi-upgrader@0.2.15", "", { "dependencies": { "@scalar/openapi-types": "0.9.5" } }, "sha512-yqROK9U96ElasEL4Wl/+PIjQZlqrQXVUUpXk9PA6xBnrp8KdEv7at8pR5gsZkvddJfYVwLILPlctyqUg4u4YZA=="],
+
+    "@scalar/openapi-validator": ["@scalar/openapi-validator@0.1.0", "", { "dependencies": { "@scalar/helpers": "0.11.2", "@scalar/json-schema-validator": "0.1.0", "@scalar/types": "0.18.3", "yaml": "^2.9.0" } }, "sha512-ZwUibJj0nPCdhRXCdgOvWme3EcywDPIwsfKCh912AMOWjSw4EF5Iv9MfAsKC+y8k8vrQEZ3JRcVvJcq3OwWtQQ=="],
+
+    "@scalar/types": ["@scalar/types@0.18.3", "", { "dependencies": { "@scalar/helpers": "0.11.2", "nanoid": "^5.1.6", "type-fest": "^5.8.0", "zod": "^4.4.3" } }, "sha512-hPLLxVt/ah4RpCVp5UrLEpnBEgTwf+RvPtRiSEty3QqfBJUfADMXHz+oWK6UAa/vALg2AWuJLCD8hRlyQ2ET9w=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
@@ -189,9 +202,11 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -321,7 +336,7 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -355,7 +370,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -423,6 +438,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
@@ -443,6 +460,8 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
+    "type-fest": ["type-fest@5.9.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
@@ -459,6 +478,8 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
@@ -467,9 +488,7 @@
 
     "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "@scalar/openapi-types/zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
-
-    "@scalar/types/zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
+    "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 

--- a/package.json
+++ b/package.json
@@ -74,14 +74,15 @@
         "release": "npm run build && npm run test && npm publish --access public"
     },
     "devDependencies": {
-        "@apidevtools/swagger-parser": "^12.1.0",
-        "@scalar/types": "^0.2.16",
+        "@apidevtools/swagger-parser": "^13.0.0",
+        "@scalar/openapi-parser": "^0.29.0",
+        "@scalar/openapi-types": "^0.9.5",
+        "@scalar/types": "^0.18.3",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
         "effect": "^3.21.2",
         "elysia": "1.4.25",
         "eslint": "9.6.0",
-        "openapi-types": "^12.1.3",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "zod": "^4.3.6"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,10 @@ type OpenAPIDocument = {
 const DEFAULT_OPENAPI_VERSION: OpenAPIVersion = '3.1.2'
 
 const normalizeOpenAPIVersion = (version: string): OpenAPIVersion => {
-	if (/^3\.(0|1)\.\d+$/.test(version)) return version as OpenAPIVersion
+	if (/^3\.(0|1|2)\.\d+$/.test(version)) return version as OpenAPIVersion
 
 	console.warn(
-		`[@elysiajs/openapi] Invalid openapiVersion "${version}". Falling back to ${DEFAULT_OPENAPI_VERSION}.`
+		`[@elysiajs/openapi] Invalid openapiVersion "${version}". Expected 3.0.x, 3.1.x, or 3.2.x. Falling back to ${DEFAULT_OPENAPI_VERSION}.`
 	)
 	return DEFAULT_OPENAPI_VERSION
 }
@@ -94,7 +94,8 @@ export const openapi = <
 			tags: !exclude?.tags
 				? documentation.tags
 				: documentation.tags?.filter(
-						(tag) => !exclude.tags?.includes(tag.name)
+						(tag: { name: string }) =>
+							!exclude.tags?.includes(tag.name)
 					),
 			info: {
 				title: 'Elysia Documentation',
@@ -206,6 +207,24 @@ export const openapi = <
 
 export { fromTypes } from './gen'
 export { toOpenAPISchema, withHeaders } from './openapi'
-export type { ElysiaOpenAPIConfig, OpenAPIVersion }
+export type {
+	ElysiaOpenAPIConfig,
+	OpenAPI32ComponentsObject,
+	OpenAPI32DiscriminatorObject,
+	OpenAPI32Documentation,
+	OpenAPI32EncodingObject,
+	OpenAPI32ExampleObject,
+	OpenAPI32MediaTypeObject,
+	OpenAPI32OAuth2SecurityScheme,
+	OpenAPI32OAuthFlowObject,
+	OpenAPI32OperationObject,
+	OpenAPI32PathItemObject,
+	OpenAPI32ResponseObject,
+	OpenAPI32SecuritySchemeObject,
+	OpenAPI32ServerObject,
+	OpenAPI32TagObject,
+	OpenAPIDocumentation,
+	OpenAPIVersion
+} from './types'
 
 export default openapi

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -7,7 +7,7 @@ import type {
 	StandardSchemaV1Like
 } from 'elysia/types'
 
-import type { OpenAPIV3 } from 'openapi-types'
+import type { OpenAPIV3, OpenAPIV3_2 } from '@scalar/openapi-types'
 import { Kind, TAnySchema, type TObject } from '@sinclair/typebox'
 
 import type {
@@ -15,6 +15,7 @@ import type {
 	AdditionalReferences,
 	ElysiaOpenAPIConfig,
 	MapJsonSchema,
+	OpenAPI32OperationObject,
 	OpenAPIVersion
 } from './types'
 
@@ -38,6 +39,20 @@ const toOperationId = (method: string, paths: string) => {
 
 	return operationId
 }
+
+const OPENAPI_HTTP_METHODS = new Set([
+	'get',
+	'post',
+	'put',
+	'delete',
+	'patch',
+	'head',
+	'options',
+	'trace'
+])
+
+const isOpenAPI32 = (version: OpenAPIVersion) =>
+	version.startsWith('3.2.')
 
 const optionalParamsRegex = /(\/:\w+\?)/g
 
@@ -965,7 +980,7 @@ export function toOpenAPISchema(
 			? [exclude.paths]
 			: []
 
-	const paths: OpenAPIV3.PathsObject = Object.create(null)
+	const paths: OpenAPIV3_2.PathsObject = Object.create(null)
 	// @ts-ignore
 	const definitions = app.getGlobalDefinitions?.().type
 
@@ -986,9 +1001,22 @@ export function toOpenAPISchema(
 	for (const route of routes) {
 		if (route.hooks?.detail?.hide) continue
 
-		const method = route.method.toLowerCase()
+		const rawMethod = String(route.method)
+		const method = rawMethod.toLowerCase()
+		const supportsOpenAPI32 = isOpenAPI32(openapiVersion)
+		const isOpenAPI32Method = supportsOpenAPI32 && method === 'query'
+		const isAdditionalOperation =
+			supportsOpenAPI32 &&
+			method !== 'all' &&
+			method !== 'ws' &&
+			!OPENAPI_HTTP_METHODS.has(method) &&
+			!isOpenAPI32Method
 
 		if (
+			(method !== 'all' &&
+				!OPENAPI_HTTP_METHODS.has(method) &&
+				!isOpenAPI32Method &&
+				!isAdditionalOperation) ||
 			(excludeStaticFile && route.path.includes('.')) ||
 			excludePaths.some((exclusion) => {
 				if (exclusion instanceof RegExp) {
@@ -1004,7 +1032,7 @@ export function toOpenAPISchema(
 			continue
 
 		const hooks: InputSchema & {
-			detail: Partial<OpenAPIV3.OperationObject>
+			detail: Partial<OpenAPI32OperationObject>
 		} = route.hooks ?? {}
 
 		if (references?.length)
@@ -1064,12 +1092,12 @@ export function toOpenAPISchema(
 
 		if (
 			excludeTags &&
-			hooks.detail.tags?.some((tag) => excludeTags?.includes(tag))
+			hooks.detail.tags?.some((tag: string) => excludeTags?.includes(tag))
 		)
 			continue
 
 		// Start building the operation object
-		const operation: Partial<OpenAPIV3.OperationObject> = {
+		const operation: Partial<OpenAPI32OperationObject> = {
 			...hooks.detail
 		}
 
@@ -1318,10 +1346,16 @@ export function toOpenAPISchema(
 			const current = paths[path] as any
 
 			if (method !== 'all') {
-				current[method] = {
+				const describedOperation = {
 					...operation,
 					operationId
 				}
+
+				if (isAdditionalOperation) {
+					current.additionalOperations ??= {}
+					current.additionalOperations[rawMethod] = describedOperation
+				} else current[method] = describedOperation
+
 				continue
 			}
 
@@ -1334,7 +1368,8 @@ export function toOpenAPISchema(
 				'patch',
 				'head',
 				'options',
-				'trace'
+				'trace',
+				...(supportsOpenAPI32 ? ['query'] : [])
 			])
 				current[method] = {
 					...operation,
@@ -1363,7 +1398,7 @@ export function toOpenAPISchema(
 			schemas
 		},
 		paths
-	} satisfies Pick<OpenAPIV3.Document, 'paths' | 'components'>
+	} satisfies Pick<OpenAPIV3_2.Document, 'paths' | 'components'>
 }
 
 type ResponseHeaderSchemas = Record<

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,4 +1,4 @@
-import type { OpenAPIV3 } from 'openapi-types'
+import type { OpenAPIV3 } from '@scalar/openapi-types'
 import { ElysiaOpenAPIConfig } from '../types'
 
 const elysiaCSS = `.light-mode {

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3 } from 'openapi-types'
+import type { OpenAPIV3 } from '@scalar/openapi-types'
 import { ElysiaOpenAPIConfig } from '../types'
 import { SwaggerUIOptions } from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,23 +1,180 @@
 import type { TSchema } from 'elysia'
-import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types'
+import type {
+	OpenAPIV3,
+	OpenAPIV3_1,
+	OpenAPIV3_2
+} from '@scalar/openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
 
 export type OpenAPIProvider = 'scalar' | 'swagger-ui' | null
-export type OpenAPIVersion = `3.0.${number}` | `3.1.${number}`
+export type OpenAPIVersion =
+	| `3.0.${number}`
+	| `3.1.${number}`
+	| `3.2.${number}`
 
 type MaybeArray<T> = T | T[]
-type OpenAPIDocumentation =
-	| Omit<
-			Partial<OpenAPIV3.Document>,
-			| 'x-express-openapi-additional-middleware'
-			| 'x-express-openapi-validation-strict'
-	  >
-	| Omit<
-			Partial<OpenAPIV3_1.Document>,
-			| 'x-express-openapi-additional-middleware'
-			| 'x-express-openapi-validation-strict'
-	  >
+
+export type OpenAPI32TagObject = OpenAPIV3_2.TagObject
+export type OpenAPI32ServerObject = OpenAPIV3_2.ServerObject
+
+export type OpenAPI32DiscriminatorObject = Omit<
+	OpenAPIV3_2.DiscriminatorObject,
+	'propertyName'
+> & {
+	propertyName?: string
+	defaultMapping?: string
+}
+
+export type OpenAPI32ExampleObject = OpenAPIV3_2.ExampleObject
+
+export type OpenAPI32EncodingObject = Omit<
+	OpenAPIV3_2.EncodingObject,
+	'headers'
+> & {
+	headers?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPIV3_2.HeaderObject
+	>
+	encoding?: Record<string, OpenAPI32EncodingObject>
+	prefixEncoding?: OpenAPI32EncodingObject[]
+	itemEncoding?: OpenAPI32EncodingObject
+}
+
+export type OpenAPI32MediaTypeObject = Omit<
+	OpenAPIV3_2.MediaTypeObject,
+	'encoding' | 'examples'
+> & {
+	description?: string
+	itemSchema?:
+		| OpenAPIV3_2.SchemaObject
+		| OpenAPIV3_2.ReferenceObject
+	examples?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPI32ExampleObject
+	>
+	encoding?: Record<string, OpenAPI32EncodingObject>
+	prefixEncoding?: OpenAPI32EncodingObject[]
+	itemEncoding?: OpenAPI32EncodingObject
+}
+
+export type OpenAPI32ResponseObject = Omit<
+	OpenAPIV3_2.ResponseObject,
+	'description' | 'content'
+> & {
+	summary?: string
+	description?: string
+	content?: Record<string, OpenAPI32MediaTypeObject>
+}
+
+export type OpenAPI32OAuthFlowObject = {
+	authorizationUrl?: string
+	tokenUrl?: string
+	deviceAuthorizationUrl?: string
+	refreshUrl?: string
+	scopes: Record<string, string>
+}
+
+export type OpenAPI32OAuth2SecurityScheme = Omit<
+	OpenAPIV3_2.OAuth2SecurityScheme,
+	'flows'
+> & {
+	deprecated?: boolean
+	oauth2MetadataUrl?: string
+	flows: {
+		implicit?: OpenAPI32OAuthFlowObject
+		password?: OpenAPI32OAuthFlowObject
+		clientCredentials?: OpenAPI32OAuthFlowObject
+		authorizationCode?: OpenAPI32OAuthFlowObject
+		deviceAuthorization?: OpenAPI32OAuthFlowObject
+	}
+}
+
+export type OpenAPI32SecuritySchemeObject =
+	| (OpenAPIV3_2.SecuritySchemeObject & { deprecated?: boolean })
+	| OpenAPI32OAuth2SecurityScheme
+
+export type OpenAPI32OperationObject = Omit<
+	OpenAPIV3_2.OperationObject,
+	'responses' | 'servers'
+> & {
+	responses?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPI32ResponseObject
+	>
+	servers?: OpenAPI32ServerObject[]
+}
+
+export type OpenAPI32PathItemObject = Omit<
+	OpenAPIV3_2.PathItemObject,
+	| 'get'
+	| 'put'
+	| 'post'
+	| 'delete'
+	| 'options'
+	| 'head'
+	| 'patch'
+	| 'trace'
+	| 'query'
+	| 'additionalOperations'
+	| 'servers'
+> & {
+	get?: OpenAPI32OperationObject
+	put?: OpenAPI32OperationObject
+	post?: OpenAPI32OperationObject
+	delete?: OpenAPI32OperationObject
+	options?: OpenAPI32OperationObject
+	head?: OpenAPI32OperationObject
+	patch?: OpenAPI32OperationObject
+	trace?: OpenAPI32OperationObject
+	query?: OpenAPI32OperationObject
+	additionalOperations?: Record<string, OpenAPI32OperationObject>
+	servers?: OpenAPI32ServerObject[]
+}
+
+export type OpenAPI32ComponentsObject = Omit<
+	OpenAPIV3_2.ComponentsObject,
+	'responses' | 'securitySchemes' | 'mediaTypes'
+> & {
+	responses?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPI32ResponseObject
+	>
+	securitySchemes?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPI32SecuritySchemeObject
+	>
+	mediaTypes?: Record<
+		string,
+		OpenAPIV3_2.ReferenceObject | OpenAPI32MediaTypeObject
+	>
+}
+
+export type OpenAPI32Documentation = Omit<
+	Partial<OpenAPIV3_2.Document>,
+	'components' | 'paths' | 'servers' | 'tags' | 'webhooks'
+> & {
+	$self?: string
+	components?: OpenAPI32ComponentsObject
+	paths?: Record<string, OpenAPI32PathItemObject | undefined>
+	servers?: OpenAPI32ServerObject[]
+	tags?: OpenAPI32TagObject[]
+	webhooks?: Record<
+		string,
+		OpenAPI32PathItemObject | OpenAPIV3_2.ReferenceObject
+	>
+}
+
+type DocumentationWithoutExpressExtensions<T> = Omit<
+	T,
+	| 'x-express-openapi-additional-middleware'
+	| 'x-express-openapi-validation-strict'
+>
+
+export type OpenAPIDocumentation =
+	| DocumentationWithoutExpressExtensions<Partial<OpenAPIV3.Document>>
+	| DocumentationWithoutExpressExtensions<Partial<OpenAPIV3_1.Document>>
+	| DocumentationWithoutExpressExtensions<OpenAPI32Documentation>
 
 export type MapJsonSchema = { [vendor: string]: Function } & {
 	[vendor in  // schema['~standard'].vendor
@@ -146,7 +303,7 @@ export interface ElysiaOpenAPIConfig<
 	 *'
 	 * @see https://github.com/scalar/scalar/blob/main/documentation/configuration.md
 	 */
-	scalar?: ApiReferenceConfiguration & {
+	scalar?: Partial<ApiReferenceConfiguration> & {
 		/**
 		 * Version to use for Scalar cdn bundle
 		 *

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type OpenAPI32DiscriminatorObject = Omit<
 	OpenAPIV3_2.DiscriminatorObject,
 	'propertyName'
 > & {
-	propertyName?: string
+	propertyName: string
 	defaultMapping?: string
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,6 +92,7 @@ describe('Swagger', () => {
 										{ $ref: '#/components/schemas/FallbackEvent' }
 									],
 									discriminator: {
+										propertyName: 'eventType',
 										defaultMapping:
 											'#/components/schemas/FallbackEvent'
 									}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from 'elysia'
 import SwaggerParser from '@apidevtools/swagger-parser'
+import { validate as validateOpenAPI } from '@scalar/openapi-parser'
 import { openapi } from '../src'
 
 import { describe, expect, it } from 'bun:test'
@@ -47,6 +48,116 @@ describe('Swagger', () => {
 		expect(document.openapi).toBe('3.0.3')
 		expect(schema).toMatchObject({ type: 'string', nullable: true })
 		await SwaggerParser.validate(document).catch((error) => fail(error))
+	})
+
+	it('emits and validates OpenAPI 3.2 documents', async () => {
+		const app = new Elysia()
+			.use(
+				openapi({
+					openapiVersion: '3.2.0',
+					documentation: {
+						$self: 'https://example.com/openapi.json',
+						paths: {
+							'/status': {
+								get: {
+									responses: {
+										'200': { summary: 'Service is healthy' }
+									}
+								}
+							}
+						},
+						servers: [
+							{
+								name: 'production',
+								url: 'https://api.example.com'
+							}
+						],
+						tags: [
+							{
+								name: 'books',
+								summary: 'Books',
+								parent: 'products',
+								kind: 'nav'
+							}
+						],
+						components: {
+							schemas: {
+								Event: {
+									type: 'string',
+									xml: { nodeType: 'text' }
+								},
+								FallbackEvent: { type: 'object' },
+								EventEnvelope: {
+									oneOf: [
+										{ $ref: '#/components/schemas/FallbackEvent' }
+									],
+									discriminator: {
+										defaultMapping:
+											'#/components/schemas/FallbackEvent'
+									}
+								}
+							},
+							securitySchemes: {
+								LegacyKey: {
+									type: 'apiKey',
+									name: 'x-api-key',
+									in: 'header',
+									deprecated: true
+								},
+								DeviceOAuth: {
+									type: 'oauth2',
+									oauth2MetadataUrl:
+										'https://auth.example.com/.well-known/oauth-authorization-server',
+									flows: {
+										deviceAuthorization: {
+											deviceAuthorizationUrl:
+												'https://auth.example.com/device',
+											tokenUrl: 'https://auth.example.com/token',
+											scopes: { read: 'Read books' }
+										}
+									}
+								}
+							},
+							mediaTypes: {
+								EventStream: {
+									description: 'Server-sent events',
+									itemSchema: {
+										type: 'object',
+										properties: {
+											data: { type: 'string' }
+										}
+									}
+								}
+							}
+						}
+					}
+				})
+			)
+			.route('QUERY', '/books/search', () => ({ found: 0 }), {
+				body: t.Object({ filter: t.String() }),
+				response: t.Object({ found: t.Number() })
+			})
+			.route('PROPFIND', '/books', () => 'ok')
+
+		await app.modules
+
+		const document = await app
+			.handle(req('/openapi/json'))
+			.then((response) => response.json())
+
+		expect(document.openapi).toBe('3.2.0')
+		expect(document.$self).toBe('https://example.com/openapi.json')
+		expect(document.paths['/books/search'].query.requestBody).toBeDefined()
+		expect(
+			document.paths['/books'].additionalOperations.PROPFIND.operationId
+		).toBe('propfindBooks')
+		expect(document.paths['/status'].get.responses['200']).toEqual({
+			summary: 'Service is healthy'
+		})
+
+		const validation = await validateOpenAPI(document)
+		expect(validation.valid).toBe(true)
+		expect(validation.errors).toEqual([])
 	})
 
 	it('use custom Swagger version', async () => {

--- a/test/openapi/exclude-paths.test.ts
+++ b/test/openapi/exclude-paths.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from 'bun:test'
-import { Elysia } from 'elysia'
+import { Elysia, type AnyElysia } from 'elysia'
 
 import { toOpenAPISchema } from '../../src/openapi'
 
-const getPathKeys = (app: Elysia, exclude?: Parameters<typeof toOpenAPISchema>[1]) =>
+const getPathKeys = (
+	app: AnyElysia,
+	exclude?: Parameters<typeof toOpenAPISchema>[1]
+) =>
 	Object.keys(toOpenAPISchema(app, exclude).paths)
 
 const app = new Elysia()

--- a/test/openapi/null-to-openapi.test.ts
+++ b/test/openapi/null-to-openapi.test.ts
@@ -26,5 +26,11 @@ describe('OpenAPI > nullToOpenApi', () => {
 			},
 			default: { type: 'null', reason: 'metadata' }
 		})
+		expect(nullToOpenApi(schema, '3.2.0')).toMatchObject({
+			properties: {
+				promoCode: { type: ['string', 'null'] }
+			},
+			default: { type: 'null', reason: 'metadata' }
+		})
 	})
 })

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -40,6 +40,89 @@ describe('OpenAPI > toOpenAPISchema', () => {
 		})
 	})
 
+	it('excludes websocket routes from OpenAPI paths', () => {
+		const app = new Elysia()
+			.ws('/v1/events/ws', {
+				message() {}
+			})
+			.get('/health', () => 'ok')
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect(schema.paths['/v1/events/ws']).toBeUndefined()
+		expect(schema.paths['/health'].get).toBeDefined()
+	})
+
+	it('emits QUERY routes only for OpenAPI 3.2', () => {
+		const app = new Elysia().route('QUERY', '/search', () => 'ok', {
+			body: t.Object({ filter: t.String() })
+		})
+
+		const openapi31 = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(
+					app,
+					undefined,
+					undefined,
+					undefined,
+					'3.1.2'
+				)
+			)
+		)
+		const openapi32 = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(
+					app,
+					undefined,
+					undefined,
+					undefined,
+					'3.2.0'
+				)
+			)
+		)
+
+		expect(openapi31.paths['/search']).toBeUndefined()
+		expect(openapi32.paths['/search'].query.requestBody).toBeDefined()
+		expect(openapi32.paths['/search'].query.operationId).toBe('querySearch')
+	})
+
+	it('uses additionalOperations for other OpenAPI 3.2 methods', () => {
+		const app = new Elysia()
+			.route('PROPFIND', '/dav', () => 'ok')
+			.route('CUSTOM', '/custom', () => 'ok')
+		const openapi31 = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(
+					app,
+					undefined,
+					undefined,
+					undefined,
+					'3.1.2'
+				)
+			)
+		)
+		const openapi32 = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(
+					app,
+					undefined,
+					undefined,
+					undefined,
+					'3.2.0'
+				)
+			)
+		)
+
+		expect(openapi31.paths['/dav']).toBeUndefined()
+		expect(openapi32.paths['/dav'].propfind).toBeUndefined()
+		expect(
+			openapi32.paths['/dav'].additionalOperations.PROPFIND.operationId
+		).toBe('propfindDav')
+		expect(
+			openapi32.paths['/custom'].additionalOperations.CUSTOM.operationId
+		).toBe('customCustom')
+	})
+
 	it('handle params', () => {
 		const app = new Elysia().get('/user/:user', () => 'hello', {
 			params: t.Object({


### PR DESCRIPTION
## Summary

- add OpenAPI 3.2 version selection and typed document fields
- emit `QUERY` and arbitrary HTTP methods through `additionalOperations`
- keep WebSocket routes out of OpenAPI paths
- replace `openapi-types` with Scalar's OpenAPI 3.2 types and parser validation
- retain existing OpenAPI 3.0 and 3.1 schema behavior

## OpenAPI 3.2 coverage

The public configuration types cover the new top-level, server, tag,
discriminator, media type, response, XML, and OAuth/security fields used by
3.2 documents. Generated paths support `QUERY`; other registered HTTP methods
are emitted with their original method name under `additionalOperations`.

## Validation

- `bun run build`
- `bunx tsc --noEmit`
- `npm test` (104 Bun tests plus CommonJS and ESM Node.js smoke tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating and validating OpenAPI 3.2 documents.
  - Added support for `QUERY` routes and non-standard HTTP methods through OpenAPI 3.2 operation fields.
  - Expanded public OpenAPI types and documentation configuration support.
  - Allowed partial Scalar API Reference configuration.

- **Documentation**
  - Updated usage guidance with OpenAPI 3.2 capabilities and method-handling details.

- **Tests**
  - Added coverage for OpenAPI 3.2 metadata, schemas, security, media types, routes, and parser validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->